### PR TITLE
Include JSP extras when they exist

### DIFF
--- a/spring/common-controller/src/main/java/org/n52/sos/web/JstlFunctions.java
+++ b/spring/common-controller/src/main/java/org/n52/sos/web/JstlFunctions.java
@@ -28,6 +28,8 @@
  */
 package org.n52.sos.web;
 
+import java.io.File;
+
 import javax.servlet.ServletContext;
 
 import org.n52.sos.service.DatabaseSettingsHandler;
@@ -68,6 +70,10 @@ public class JstlFunctions {
         return true;
     }
 
+    public static boolean viewExists(ServletContext ctx, String path) {
+        return new File(ctx.getRealPath("WEB-INF/views/" + path)).exists();
+    }
+    
     private JstlFunctions() {
     }
 }

--- a/spring/views/src/main/webapp/WEB-INF/tld/functions.tld
+++ b/spring/views/src/main/webapp/WEB-INF/tld/functions.tld
@@ -23,4 +23,9 @@
         <function-class>org.n52.sos.web.JstlFunctions</function-class>
         <function-signature>boolean hasAdministrator()</function-signature>
     </function>
+    <function>
+        <name>viewExists</name>
+        <function-class>org.n52.sos.web.JstlFunctions</function-class>
+        <function-signature>boolean viewExists(javax.servlet.ServletContext, java.lang.String)</function-signature>
+    </function>    
 </taglib>

--- a/spring/views/src/main/webapp/WEB-INF/views/common/header.jsp
+++ b/spring/views/src/main/webapp/WEB-INF/views/common/header.jsp
@@ -152,6 +152,10 @@
                                                             <span class="menu-title">Reset</span>
                                                         </a>
                                                     </li>
+                                                    <%-- include extra admin menu items if file exists (used by custom builds) --%>
+                                                    <c:if test="${sos:viewExists(pageContext.servletContext, 'common/extra-admin-menu-items.jsp')}">
+                                                        <jsp:include page="extra-admin-menu-items.jsp" />
+                                                    </c:if>
                                                 </ul>
                                             </sec:authorize>
                                         </li>
@@ -163,7 +167,7 @@
 											</a>
 										</li>
 									</sec:authorize>
-								</ul>                                   
+								</ul>
 							</div>
 						</div>
 					</div>

--- a/spring/views/src/main/webapp/WEB-INF/views/common/logotitle.jsp
+++ b/spring/views/src/main/webapp/WEB-INF/views/common/logotitle.jsp
@@ -29,6 +29,11 @@
 
 --%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@ taglib prefix="sos" uri="http://52north.org/communities/sensorweb/sos/tags" %>
+<%-- include extra title jsp if file exists (used by custom builds) --%>
+<c:if test="${sos:viewExists(pageContext.servletContext, 'common/extra-title.jsp')}">
+    <jsp:include page="extra-title.jsp" />
+</c:if>
 <div class="row">
 	<div class="span9">
 


### PR DESCRIPTION
Adds support for two optional extra JSP files:

extra-admin-menu-items.jsp in common/header.jsp
extra-title.jsp in common/logotitle.jsp

This allows custom builds (e.g. IOOS build) to add extra admin menu items and title information while still using the upstream logotitle.jsp and header.jsp files.
