### PR TITLE
Enable admin/sensors to work with non-default procedure description formats

### DIFF
--- a/core/api/src/main/java/org/n52/sos/ds/ProcedureFormatDAO.java
+++ b/core/api/src/main/java/org/n52/sos/ds/ProcedureFormatDAO.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2012-2014 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *     - Apache License, version 2.0
+ *     - Apache Software License, version 1.0
+ *     - GNU Lesser General Public License, version 3
+ *     - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *     - Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public
+ * License version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ */
+package org.n52.sos.ds;
+
+import java.util.Map;
+
+import org.n52.sos.ogc.ows.OwsExceptionReport;
+
+/**
+ * @author Shane StClair <shane@axiomalaska.com>
+ */
+public interface ProcedureFormatDAO {
+    Map<String,String> getProcedureFormatMap() throws OwsExceptionReport;
+}

--- a/core/api/src/main/java/org/n52/sos/util/ServiceLoaderHelper.java
+++ b/core/api/src/main/java/org/n52/sos/util/ServiceLoaderHelper.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2012-2014 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *     - Apache License, version 2.0
+ *     - Apache Software License, version 1.0
+ *     - GNU Lesser General Public License, version 3
+ *     - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *     - Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public
+ * License version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ */
+package org.n52.sos.util;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+import org.n52.sos.exception.ows.concrete.NoImplementationFoundException;
+
+public class ServiceLoaderHelper {
+    /**
+     * Return an implementation of a class, loaded by the ServiceLoader
+     * 
+     * @param clazz The class to load
+     * @return An implementation of the class
+     * @throws NoImplementationFoundException
+     */
+    public static <T> T loadImplementation(Class<T> clazz) throws NoImplementationFoundException {
+        T impl = null;
+        ServiceLoader<T> sl = ServiceLoader.load(clazz);
+        Iterator<T> i = sl.iterator();
+        //TODO throw exception if more than one implementation is found?
+        impl = i.hasNext() ? i.next() : null;
+        if (impl == null) {
+            throw new NoImplementationFoundException(clazz);
+        }
+        return impl;
+    }
+}

--- a/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/admin/HibernateProcedureFormatDAO.java
+++ b/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/admin/HibernateProcedureFormatDAO.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2012-2014 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *     - Apache License, version 2.0
+ *     - Apache Software License, version 1.0
+ *     - GNU Lesser General Public License, version 3
+ *     - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *     - Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public
+ * License version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ */
+package org.n52.sos.ds.hibernate.admin;
+
+import java.util.Map;
+
+import org.hibernate.Session;
+import org.n52.sos.ds.ProcedureFormatDAO;
+import org.n52.sos.ds.hibernate.HibernateSessionHolder;
+import org.n52.sos.ds.hibernate.dao.ProcedureDAO;
+import org.n52.sos.ogc.ows.OwsExceptionReport;
+
+/**
+ * @author Shane StClair <shane@axiomalaska.com>
+ */
+public class HibernateProcedureFormatDAO implements ProcedureFormatDAO {
+    private HibernateSessionHolder sessionHolder = new HibernateSessionHolder();
+
+    @Override
+    public Map<String, String> getProcedureFormatMap() throws OwsExceptionReport {
+        Session s = null;
+        Map<String,String> procedureFormatMap = null;
+        try {
+            s = sessionHolder.getSession();
+            procedureFormatMap = new ProcedureDAO().getProcedureFormatMap(s);
+        } finally {
+            sessionHolder.returnSession(s);
+        }        
+        return procedureFormatMap;
+    }
+}

--- a/hibernate/dao/src/main/resources/META-INF/services/org.n52.sos.ds.ProcedureFormatDAO
+++ b/hibernate/dao/src/main/resources/META-INF/services/org.n52.sos.ds.ProcedureFormatDAO
@@ -1,0 +1,1 @@
+org.n52.sos.ds.hibernate.admin.HibernateProcedureFormatDAO

--- a/spring/admin-controller/src/main/java/org/n52/sos/web/admin/AdminDeleteDeletedObservationsController.java
+++ b/spring/admin-controller/src/main/java/org/n52/sos/web/admin/AdminDeleteDeletedObservationsController.java
@@ -28,12 +28,10 @@
  */
 package org.n52.sos.web.admin;
 
-import java.util.Iterator;
-import java.util.ServiceLoader;
-
 import org.n52.sos.ds.DeleteDeletedObservationDAO;
 import org.n52.sos.exception.ows.concrete.NoImplementationFoundException;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
+import org.n52.sos.util.ServiceLoaderHelper;
 import org.n52.sos.web.ControllerConstants;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
@@ -54,12 +52,7 @@ public class AdminDeleteDeletedObservationsController extends AbstractAdminContr
 
     private DeleteDeletedObservationDAO getDAO() throws NoImplementationFoundException {
         if (this.dao == null) {
-            ServiceLoader<DeleteDeletedObservationDAO> sl = ServiceLoader.load(DeleteDeletedObservationDAO.class);
-            Iterator<DeleteDeletedObservationDAO> i = sl.iterator();
-            this.dao = i.hasNext() ? i.next() : null;
-            if (this.dao == null) {
-                throw new NoImplementationFoundException(DeleteDeletedObservationDAO.class);
-            }
+            this.dao = ServiceLoaderHelper.loadImplementation(DeleteDeletedObservationDAO.class);
         }
         return this.dao;
     }

--- a/spring/admin-controller/src/main/java/org/n52/sos/web/admin/AdminRenameObservablePropertyController.java
+++ b/spring/admin-controller/src/main/java/org/n52/sos/web/admin/AdminRenameObservablePropertyController.java
@@ -30,9 +30,7 @@ package org.n52.sos.web.admin;
 
 
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.ServiceLoader;
 
 import org.n52.sos.cache.ContentCache;
 import org.n52.sos.ds.RenameDAO;
@@ -41,6 +39,7 @@ import org.n52.sos.exception.NoSuchObservablePropertyException;
 import org.n52.sos.exception.ows.concrete.NoImplementationFoundException;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
 import org.n52.sos.service.Configurator;
+import org.n52.sos.util.ServiceLoaderHelper;
 import org.n52.sos.web.ControllerConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,12 +93,7 @@ public class AdminRenameObservablePropertyController extends AbstractAdminContro
 
     private RenameDAO getRenameDao() throws NoImplementationFoundException {
         if (this.dao == null) {
-            ServiceLoader<RenameDAO> sl = ServiceLoader.load(RenameDAO.class);
-            Iterator<RenameDAO> i = sl.iterator();
-            this.dao = i.hasNext() ? i.next() : null;
-            if (this.dao == null) {
-                throw new NoImplementationFoundException(RenameDAO.class);
-            }
+            this.dao = ServiceLoaderHelper.loadImplementation(RenameDAO.class);
         }
         return this.dao;
     }

--- a/spring/admin-controller/src/main/java/org/n52/sos/web/admin/SensorDescriptionController.java
+++ b/spring/admin-controller/src/main/java/org/n52/sos/web/admin/SensorDescriptionController.java
@@ -30,24 +30,31 @@ package org.n52.sos.web.admin;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
 import org.n52.sos.binding.Binding;
 import org.n52.sos.binding.BindingRepository;
 import org.n52.sos.decode.OperationDecoderKey;
+import org.n52.sos.ds.ProcedureFormatDAO;
 import org.n52.sos.exception.HTTPException;
+import org.n52.sos.exception.ows.concrete.NoImplementationFoundException;
+import org.n52.sos.ogc.ows.OwsExceptionReport;
 import org.n52.sos.ogc.sos.Sos2Constants;
 import org.n52.sos.ogc.sos.SosConstants;
 import org.n52.sos.service.Configurator;
+import org.n52.sos.util.ServiceLoaderHelper;
 import org.n52.sos.util.http.MediaTypes;
 import org.n52.sos.web.ControllerConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.servlet.ModelAndView;
 
 import com.google.common.collect.Lists;
@@ -63,6 +70,8 @@ public class SensorDescriptionController extends AbstractAdminController {
     
     private static final String SENSORS = "sensors";
     
+    private static final String PROCEDURE_FORMAT_MAP = "procedureFormatMap";
+    
     private static final String IS_UPDATE_SENSOR_SUPPORTED = "isUpdateSensorSupported";
     
     private static final String IS_DESCRIBE_SENSOR_SUPPORTED = "isDescribeSensorSupported";
@@ -70,7 +79,9 @@ public class SensorDescriptionController extends AbstractAdminController {
     private static final String IS_DELETE_SENSOR_SUPPORTED = "isDeleteSensorSupported";
     
     private static final String DESCRIBE_SENSOR_REQUEST_METHOD = "describeSensorRequestMethod";
-    
+
+    private ProcedureFormatDAO dao;
+
     private static final OperationDecoderKey DESCRIBE_SENSOR_DECODER_KEY_SOAP = new OperationDecoderKey(
             SosConstants.SOS,
             Sos2Constants.SERVICEVERSION,
@@ -108,7 +119,7 @@ public class SensorDescriptionController extends AbstractAdminController {
             MediaTypes.APPLICATION_SOAP_XML);
     
     @RequestMapping(method = RequestMethod.GET)
-    public ModelAndView view() {
+    public ModelAndView view() throws OwsExceptionReport {
         Map<String, Object> model = new HashMap<String, Object>(5);
 		boolean getKvp = false, getSoap = false, update = false, delete = false;
         try {
@@ -147,8 +158,21 @@ public class SensorDescriptionController extends AbstractAdminController {
         List<String> procedures = Lists.newArrayList(Configurator.getInstance().getCache().getProcedures());
         Collections.sort(procedures);
         model.put(SENSORS, procedures);
-        
+        model.put(PROCEDURE_FORMAT_MAP, getProcedureFormatDao().getProcedureFormatMap());
         return new ModelAndView(ControllerConstants.Views.ADMIN_SENSOR_DESCRIPTIONS, model);
     }
-    
+
+    private ProcedureFormatDAO getProcedureFormatDao() throws NoImplementationFoundException {
+        if (this.dao == null) {
+            this.dao = ServiceLoaderHelper.loadImplementation(ProcedureFormatDAO.class);
+        }
+        return this.dao;
+    }
+
+    @ResponseBody
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(NoImplementationFoundException.class)
+    public String onError(NoImplementationFoundException e) {
+        return String.format("No ProcedureFormatDAO implementation found!");
+    }    
 }

--- a/spring/common-controller/src/main/java/org/n52/sos/web/JstlFunctions.java
+++ b/spring/common-controller/src/main/java/org/n52/sos/web/JstlFunctions.java
@@ -29,9 +29,12 @@
 package org.n52.sos.web;
 
 import java.io.File;
+import java.util.Map;
 
 import javax.servlet.ServletContext;
 
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
 import org.n52.sos.service.DatabaseSettingsHandler;
 
 /**
@@ -72,6 +75,10 @@ public class JstlFunctions {
 
     public static boolean viewExists(ServletContext ctx, String path) {
         return new File(ctx.getRealPath("WEB-INF/views/" + path)).exists();
+    }
+
+    public static String mapToJson(@SuppressWarnings("rawtypes") Map map) throws JSONException {
+        return new JSONObject(map).toString(2);
     }
     
     private JstlFunctions() {

--- a/spring/views/src/main/webapp/WEB-INF/tld/functions.tld
+++ b/spring/views/src/main/webapp/WEB-INF/tld/functions.tld
@@ -27,5 +27,10 @@
         <name>viewExists</name>
         <function-class>org.n52.sos.web.JstlFunctions</function-class>
         <function-signature>boolean viewExists(javax.servlet.ServletContext, java.lang.String)</function-signature>
+    </function>
+    <function>
+        <name>mapToJson</name>
+        <function-class>org.n52.sos.web.JstlFunctions</function-class>
+        <function-signature>java.lang.String mapToJson(java.util.Map)</function-signature>
     </function>    
 </taglib>


### PR DESCRIPTION
This commit allows the /admin/sensor procedure editing page to work with sensors using procedure description formats other than standard O&M. The formats are queried using a new ProcedureFormatDAO, implemented by HibernateProcedureFormatDAO. A ServiceLoaderHelper object is also added to ease loading of implementations by the ServiceLoader, and a mapToJson Jstl function is also added.
