### PR TITLE
Add admin cache dump

### DIFF
--- a/core/cache/pom.xml
+++ b/core/cache/pom.xml
@@ -22,6 +22,7 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>api</artifactId>
             <classifier>tests</classifier>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -32,5 +33,10 @@
             <artifactId>test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>        
     </dependencies>
 </project>

--- a/core/cache/src/test/java/org/n52/sos/cache/CacheImplTest.java
+++ b/core/cache/src/test/java/org/n52/sos/cache/CacheImplTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -43,6 +44,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.n52.sos.ogc.sos.SosEnvelope;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 
 /**
  * @author <a href="mailto:e.h.juerrens@52north.org">Eike Hinderk
@@ -106,5 +111,12 @@ public class CacheImplTest {
 
         assertThat(instance.getGlobalEnvelope(), not(nullValue()));
         assertThat(instance.getGlobalEnvelope(), is(emptySosEnvelope));
+    }
+
+    @Test
+    public void should_serialize_to_json() throws JsonProcessingException {
+        String json = new ObjectMapper().writeValueAsString(instance);
+        assertNotNull(json);
+        assertFalse(json.isEmpty());        
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <hibernate.version>4.1.12.Final</hibernate.version>
         <hibernate.spatial.version>4.1-52N</hibernate.spatial.version>
         <sqlite.version>3.7.2</sqlite.version>
+        <jackson.version>2.3.3</jackson.version>
 
         <!-- 52N dependency versions -->
         <n52.common.xml.version>1.1.5</n52.common.xml.version>
@@ -647,9 +648,14 @@
                 <version>1.0.2</version>
             </dependency>
             <dependency>
-                <artifactId>jackson-core</artifactId>
                 <groupId>com.fasterxml.jackson.core</groupId>
-                <version>2.1.4</version>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/spring/admin-controller/pom.xml
+++ b/spring/admin-controller/pom.xml
@@ -46,5 +46,9 @@
             <groupId>org.n52.sensorweb</groupId>
             <artifactId>52n-xml-sos-v20</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/spring/admin-controller/src/main/java/org/n52/sos/web/admin/AdminCacheController.java
+++ b/spring/admin-controller/src/main/java/org/n52/sos/web/admin/AdminCacheController.java
@@ -29,6 +29,10 @@
 package org.n52.sos.web.admin;
 
 import org.codehaus.jettison.json.JSONObject;
+import org.joda.time.DateTime;
+import org.n52.sos.ogc.gml.time.TimePeriod;
+import org.n52.sos.ogc.sos.SosEnvelope;
+import org.n52.sos.service.Configurator;
 import org.n52.sos.web.AbstractController;
 import org.n52.sos.web.ControllerConstants;
 import org.slf4j.Logger;
@@ -38,12 +42,23 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+
 /**
  * @since 4.0.0
  * 
  */
 @Controller
 public class AdminCacheController extends AbstractController {
+    private static final ObjectMapper objectMapper = buildObjectMapper();
+    
     @SuppressWarnings("unused")
     private static final Logger LOG = LoggerFactory.getLogger(AdminCacheController.class);
 
@@ -52,9 +67,34 @@ public class AdminCacheController extends AbstractController {
         return ControllerConstants.Views.ADMIN_CACHE;
     }
 
+    private static ObjectMapper buildObjectMapper() {
+        ObjectMapper om = new ObjectMapper();
+
+        //enable pretty printing
+        om.enable(SerializationFeature.INDENT_OUTPUT);
+        
+        //specify which types should be serialized using toString
+        SimpleModule module = new SimpleModule("CacheSerializerModule", new Version(1, 0, 0, null, null, null));
+        module.addSerializer(DateTime.class, new ToStringSerializer());
+        module.addSerializer(TimePeriod.class, new ToStringSerializer());
+        module.addSerializer(SosEnvelope.class, new ToStringSerializer());
+        om.registerModule(module);
+
+        //set property visibility
+        om.setVisibility(PropertyAccessor.GETTER, Visibility.NON_PRIVATE);
+        om.setVisibility(PropertyAccessor.IS_GETTER, Visibility.NON_PRIVATE);
+        return om;
+    }
+
     @ResponseBody
     @RequestMapping(value = ControllerConstants.Paths.ADMIN_CACHE_SUMMARY, method = RequestMethod.GET, produces = "application/json; charset=UTF-8")
     public String getCacheSummary() {
         return new JSONObject(CacheSummaryHandler.getCacheValues()).toString();
+    }
+
+    @ResponseBody
+    @RequestMapping(value = ControllerConstants.Paths.ADMIN_CACHE_DUMP, method = RequestMethod.GET, produces = "application/json; charset=UTF-8")
+    public String getCacheDump() throws JsonProcessingException {
+        return objectMapper.writeValueAsString(Configurator.getInstance().getCache());
     }
 }

--- a/spring/common-controller/src/main/java/org/n52/sos/web/ControllerConstants.java
+++ b/spring/common-controller/src/main/java/org/n52/sos/web/ControllerConstants.java
@@ -145,6 +145,8 @@ public interface ControllerConstants {
         String ADMIN_CACHE_SUMMARY = "/admin/cache/summary";
         
         String ADMIN_CACHE_LOADING = "/admin/cache/loading";
+        
+        String ADMIN_CACHE_DUMP = "/admin/cache/dump";        
 
         String ADMIN_RELOAD_CAPABILITIES_CACHE = "/admin/cache/reload";
 


### PR DESCRIPTION
Adds a JSON dump of the cache at /admin/cache/dump. Not currently included in the menus since it's an experimental feature and may not be useful for general users, but it's nice to be able to actually see what's in the cache without a debugger. Some objects get serialized a little strangely, but it's enough to tell what's going on.
