### PR TITLE
Change/spatial filtering profile observation query

### DIFF
--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/AbstractObservationDAO.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/AbstractObservationDAO.java
@@ -37,11 +37,13 @@ import java.util.Set;
 
 import org.hibernate.Criteria;
 import org.hibernate.Session;
+import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Disjunction;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projection;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
+import org.hibernate.criterion.Subqueries;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.n52.sos.ds.hibernate.entities.AbstractObservation;
@@ -1000,18 +1002,7 @@ public abstract class AbstractObservationDAO extends TimeCreator {
                 throw new OptionNotSupportedException().at(Sos2Constants.GetObservationParams.spatialFilter)
                         .withMessage("The SOS 2.0 Spatial Filtering Profile is not supported by this service!");
             }
-            Set<Long> observationIds =
-                    spatialFilteringProfileDAO.getObservationIdsForSpatialFilter(request.getSpatialFilter(),
-                            session);
-            if (CollectionHelper.isEmpty(observationIds)) {
-                c.add(Restrictions.eq(Observation.ID, Long.MIN_VALUE));
-            } else if (CollectionHelper.isNotEmpty(observationIds)) {
-                Disjunction disjunction = Restrictions.disjunction();
-                for (List<Long> list : HibernateHelper.getValidSizedLists(observationIds)) {
-                    disjunction.add(Restrictions.in(Observation.ID, list));
-                }
-                c.add(disjunction);
-            }
+            c.add(Subqueries.propertyIn(AbstractObservation.ID, spatialFilteringProfileDAO.getDetachedCriteriaFor(request.getSpatialFilter())));
         }
         
     }

--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/AbstractSpatialFilteringProfileDAO.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/AbstractSpatialFilteringProfileDAO.java
@@ -161,6 +161,8 @@ public abstract class AbstractSpatialFilteringProfileDAO<T extends AbstractSpati
      *             If an error occurs
      */
     public abstract SosEnvelope getEnvelopeForOfferingId(String offeringID, Session session) throws OwsExceptionReport;
+    
+    public abstract DetachedCriteria getDetachedCriteriaFor(SpatialFilter filter) throws OwsExceptionReport; 
 
     /**
      * Get concrete SpatialFilteringProfile entity object

--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/SpatialFilteringProfileDAO.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/SpatialFilteringProfileDAO.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hibernate.Session;
+import org.hibernate.criterion.DetachedCriteria;
 import org.n52.sos.config.annotation.Configurable;
 import org.n52.sos.ds.hibernate.entities.AbstractObservation;
 import org.n52.sos.ds.hibernate.entities.AbstractSpatialFilteringProfile;
@@ -91,6 +92,11 @@ public class SpatialFilteringProfileDAO extends AbstractSpatialFilteringProfileD
     @Override
     protected SpatialFilteringProfile getSpatialFilteringProfileImpl() {
         return new SpatialFilteringProfile();
+    }
+
+    @Override
+    public DetachedCriteria getDetachedCriteriaFor(SpatialFilter filter) throws OwsExceptionReport {
+        return getDetachedCriteria(SpatialFilteringProfile.class, filter);
     }
 
 }

--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/series/SeriesSpatialFilteringProfileDAO.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/series/SeriesSpatialFilteringProfileDAO.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hibernate.Session;
+import org.hibernate.criterion.DetachedCriteria;
 import org.n52.sos.ds.hibernate.dao.AbstractSpatialFilteringProfileDAO;
 import org.n52.sos.ds.hibernate.entities.AbstractObservation;
 import org.n52.sos.ds.hibernate.entities.AbstractSpatialFilteringProfile;
@@ -91,6 +92,11 @@ public class SeriesSpatialFilteringProfileDAO extends AbstractSpatialFilteringPr
     @Override
     protected SeriesSpatialFilteringProfile getSpatialFilteringProfileImpl() {
         return new SeriesSpatialFilteringProfile();
+    }
+
+    @Override
+    public DetachedCriteria getDetachedCriteriaFor(SpatialFilter filter) throws OwsExceptionReport{
+        return getDetachedCriteria(SeriesSpatialFilteringProfile.class, filter);
     }
 
 }


### PR DESCRIPTION
Use Hibernate Subquery instead of Restriction.in because the previously resulting query could be problematic for a large number of SpatialObservation.
