### PR TITLE
Support to query all values at once if chunk streaming is selected

### DIFF
--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/AbstractValueDAO.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/AbstractValueDAO.java
@@ -171,7 +171,9 @@ public abstract class AbstractValueDAO extends TimeCreator {
       */
      protected void addChunkValuesToCriteria(Criteria c, int chunkSize, int currentRow) {
          c.addOrder(Order.asc(AbstractValue.PHENOMENON_TIME_START));
-         c.setMaxResults(chunkSize).setFirstResult(currentRow);
+         if (chunkSize > 0) {
+             c.setMaxResults(chunkSize).setFirstResult(currentRow);
+         }
      }
 
 }

--- a/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/values/HibernateChunkStreamingValue.java
+++ b/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/values/HibernateChunkStreamingValue.java
@@ -60,6 +60,8 @@ public class HibernateChunkStreamingValue extends HibernateStreamingValue {
     private int chunkSize;
 
     private int currentRow;
+    
+    private boolean noChunk = false;
 
     /**
      * constructor
@@ -83,7 +85,12 @@ public class HibernateChunkStreamingValue extends HibernateStreamingValue {
     public boolean hasNextValue() throws OwsExceptionReport {
         boolean next = false;
         if (valuesResult == null || !valuesResult.hasNext()) {
-            getNextResults();
+            if (!noChunk) {
+                getNextResults();
+                if (chunkSize <= 0) {
+                    noChunk = true;
+                }
+            }
         }
         if (valuesResult != null) {
             next = valuesResult.hasNext();

--- a/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/values/HibernateStreamingSettings.java
+++ b/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/values/HibernateStreamingSettings.java
@@ -82,7 +82,7 @@ public class HibernateStreamingSettings implements SettingDefinitionProvider {
                     .setDefaultValue(1000)
                     .setTitle(String.format("Number of chunk size.", 1000))
                     .setDescription(
-                            "Number of chunk size, only relevant if scrollable datasource streaming is set to 'true'.")
+                            "Number of chunk size, only relevant if scrollable datasource streaming is set to 'true'. If define a number <= 0, the whole values are queried at once!")
                     .setOrder(ORDER_3);
 
     private static final Set<SettingDefinition<?, ?>> DEFINITIONS = Sets.<SettingDefinition<?, ?>> newHashSet(

--- a/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/values/series/HibernateChunkSeriesStreamingValue.java
+++ b/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/values/series/HibernateChunkSeriesStreamingValue.java
@@ -61,6 +61,8 @@ public class HibernateChunkSeriesStreamingValue extends HibernateSeriesStreaming
     private int chunkSize;
 
     private int currentRow;
+    
+    private boolean noChunk = false;
 
     /**
      * constructor
@@ -79,7 +81,12 @@ public class HibernateChunkSeriesStreamingValue extends HibernateSeriesStreaming
     public boolean hasNextValue() throws OwsExceptionReport {
         boolean next = false;
         if (seriesValuesResult == null || !seriesValuesResult.hasNext()) {
-            getNextResults();
+            if (!noChunk) {
+                getNextResults();
+                if (chunkSize <= 0) {
+                    noChunk = true;
+                }
+            }
         }
         if (seriesValuesResult != null) {
             next = seriesValuesResult.hasNext();


### PR DESCRIPTION
 Support to query all values at once if chunk streaming is selected by setting the chunk size <= 0.
