### PR TITLE
Update to #59 regarding the suggestion by shane-axiom.

### DIFF
--- a/core/api/src/main/java/org/n52/sos/service/Configurator.java
+++ b/core/api/src/main/java/org/n52/sos/service/Configurator.java
@@ -46,6 +46,7 @@ import org.n52.sos.ds.CacheFeederDAORepository;
 import org.n52.sos.ds.ConnectionProvider;
 import org.n52.sos.ds.DataConnectionProvider;
 import org.n52.sos.ds.ConnectionProviderIdentificator;
+import org.n52.sos.ds.Datasource;
 import org.n52.sos.ds.DatasourceDaoIdentifier;
 import org.n52.sos.ds.FeatureQueryHandler;
 import org.n52.sos.ds.HibernateDatasourceConstants;
@@ -95,8 +96,8 @@ public class Configurator implements Cleanupable {
     private static final Lock INIT_LOCK = new ReentrantLock();
 
     /**
-     * @return Returns the instance of the Configurator. <tt>null</tt> will
-     *         be returned if the parameterized
+     * @return Returns the instance of the Configurator. <tt>null</tt> will be
+     *         returned if the parameterized
      *         {@link #createInstance(Properties, String)} method was not
      *         invoked before. Usually this will be done in the SOS.
      *         <p/>
@@ -214,9 +215,9 @@ public class Configurator implements Cleanupable {
     private Tasking tasking;
 
     private Set<String> providedJdbcDrivers = Sets.newHashSet();
-    
+
     private String connectionProviderIdentificator;
-    
+
     private String datasourceDaoIdentificator;
 
     /**
@@ -237,11 +238,9 @@ public class Configurator implements Cleanupable {
         if (connectionProviderConfig == null) {
             logAndThrowConfigurationException("No connection provider configuration available!");
         }
-
         this.basepath = basepath;
         dataConnectionProviderProperties = connectionProviderConfig;
-        connectionProviderIdentificator = dataConnectionProviderProperties.getProperty(ConnectionProviderIdentificator.CONNECTION_PROVIDER_IDENTIFIER);
-        datasourceDaoIdentificator = dataConnectionProviderProperties.getProperty(DatasourceDaoIdentifier.DATASOURCE_DAO_IDENTIFIER);
+        getIdentificators(dataConnectionProviderProperties);
         if (Strings.isNullOrEmpty(connectionProviderIdentificator)) {
             logAndThrowConfigurationException("No connection provider identificator available!");
         }
@@ -249,6 +248,37 @@ public class Configurator implements Cleanupable {
             logAndThrowConfigurationException("No datasource DAO identificator available!");
         }
         LOGGER.info("Configurator initialized: [basepath={}]", this.basepath, dataConnectionProviderProperties);
+    }
+
+    /**
+     * Get the {@link ConnectionProviderIdentificator} and
+     * {@link DatasourceDaoIdentifier} values from {@link Datasource}
+     * implementation
+     * 
+     * @param dataConnectionProviderProperties
+     *            Datasource properties
+     */
+    private void getIdentificators(Properties dataConnectionProviderProperties2) {
+        String className = dataConnectionProviderProperties.getProperty(Datasource.class.getCanonicalName());
+        if (className == null) {
+            LOGGER.error("Can not find datasource class in datasource.properties!");
+            throw new ConfigurationException("Missing Datasource Property!");
+        }
+        try {
+            Datasource datasource = (Datasource) Class.forName(className).newInstance();
+            connectionProviderIdentificator = datasource.getConnectionProviderIdentifier();
+            datasourceDaoIdentificator = datasource.getDatasourceDaoIdentifier();
+        } catch (ClassNotFoundException ex) {
+            LOGGER.error("Can not instantiate Datasource!", ex);
+            throw new ConfigurationException(ex);
+        } catch (InstantiationException ex) {
+            LOGGER.error("Can not instantiate Datasource!", ex);
+            throw new ConfigurationException(ex);
+        } catch (IllegalAccessException ex) {
+            LOGGER.error("Can not instantiate Datasource!", ex);
+            throw new ConfigurationException(ex);
+        }
+
     }
 
     private void logAndThrowConfigurationException(String message) {
@@ -266,10 +296,10 @@ public class Configurator implements Cleanupable {
 
         SettingsManager.getInstance();
         ServiceConfiguration.getInstance();
-        
+
         initializeConnectionProviders();
         CacheFeederDAORepository.createInstance(getDatasourceDaoIdentificator());
-        
+
         serviceIdentificationFactory = new SosServiceIdentificationFactory();
         serviceProviderFactory = new SosServiceProviderFactory();
         OperationDAORepository.createInstance(getDatasourceDaoIdentificator());
@@ -286,7 +316,7 @@ public class Configurator implements Cleanupable {
         contentCacheController = loadAndConfigure(ContentCacheController.class, false);
         tasking = new Tasking();
         profileHandler = loadAndConfigure(ProfileHandler.class, false, new DefaultProfileHandler());
-        
+
         SosEventBus.fire(new ConfiguratorInitializedEvent());
         LOGGER.info("\n******\n Configurator initialization finished\n******\n");
     }
@@ -332,7 +362,8 @@ public class Configurator implements Cleanupable {
 
     /**
      * @return the implemented cache feeder DAO
-     * @deprecated use {@link CacheFeederDAORepository.getCacheFeederDAO()} instead.  
+     * @deprecated use {@link CacheFeederDAORepository.getCacheFeederDAO()}
+     *             instead.
      */
     @Deprecated
     public CacheFeederDAO getCacheFeederDAO() {

--- a/hibernate/h2/src/main/java/org/n52/sos/ds/hibernate/H2Configuration.java
+++ b/hibernate/h2/src/main/java/org/n52/sos/ds/hibernate/H2Configuration.java
@@ -55,6 +55,7 @@ import org.n52.sos.cache.ctrl.ScheduledContentCacheControllerSettings;
 import org.n52.sos.config.sqlite.SQLiteSessionFactory;
 import org.n52.sos.ds.ConnectionProviderException;
 import org.n52.sos.ds.ConnectionProviderIdentificator;
+import org.n52.sos.ds.Datasource;
 import org.n52.sos.ds.DatasourceDaoIdentifier;
 import org.n52.sos.ds.HibernateDatasourceConstants;
 import org.n52.sos.exception.ConfigurationException;
@@ -93,8 +94,7 @@ public class H2Configuration {
             put(HIBERNATE_CONNECTION_DRIVER_CLASS, H2_DRIVER);
             put(HIBERNATE_DIALECT, GeoDBDialect.class.getName());
             put(SessionFactoryProvider.HIBERNATE_RESOURCES, getResources());
-            put(ConnectionProviderIdentificator.CONNECTION_PROVIDER_IDENTIFIER, HibernateDatasourceConstants.ORM_CONNECTION_PROVIDER_IDENTIFIER);
-            put(DatasourceDaoIdentifier.DATASOURCE_DAO_IDENTIFIER, HibernateDatasourceConstants.ORM_DATASOURCE_DAO_IDENTIFIER);
+            put(Datasource.class.getCanonicalName(), MockDatasource.class.getCanonicalName());
         }
 
         private List<String> getResources() {

--- a/hibernate/h2/src/main/java/org/n52/sos/ds/hibernate/MockDatasource.java
+++ b/hibernate/h2/src/main/java/org/n52/sos/ds/hibernate/MockDatasource.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright (C) 2012-2014 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *     - Apache License, version 2.0
+ *     - Apache Software License, version 1.0
+ *     - GNU Lesser General Public License, version 3
+ *     - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *     - Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public
+ * License version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ */
+package org.n52.sos.ds.hibernate;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import org.n52.sos.config.SettingDefinition;
+import org.n52.sos.ds.Datasource;
+import org.n52.sos.ds.DatasourceCallback;
+import org.n52.sos.ds.HibernateDatasourceConstants;
+
+public class MockDatasource implements Datasource {
+
+    @Override
+    public String getConnectionProviderIdentifier() {
+        return HibernateDatasourceConstants.ORM_CONNECTION_PROVIDER_IDENTIFIER;
+    }
+
+    @Override
+    public String getDatasourceDaoIdentifier() {
+        return HibernateDatasourceConstants.ORM_DATASOURCE_DAO_IDENTIFIER;
+    }
+
+    @Override
+    public String getDialectName() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Set<SettingDefinition<?, ?>> getSettingDefinitions() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Set<SettingDefinition<?, ?>> getChangableSettingDefinitions(Properties current) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void validateConnection(Map<String, Object> settings) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void validateConnection(Properties current, Map<String, Object> newSettings) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void validatePrerequisites(Map<String, Object> settings) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void validatePrerequisites(Properties current, Map<String, Object> newSettings) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public boolean needsSchema() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public void validateSchema(Map<String, Object> settings) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void validateSchema(Properties current, Map<String, Object> newSettings) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public boolean checkIfSchemaExists(Map<String, Object> settings) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean checkIfSchemaExists(Properties current, Map<String, Object> newSettings) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean checkSchemaCreation(Map<String, Object> settings) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public String[] createSchema(Map<String, Object> settings) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public String[] dropSchema(Map<String, Object> settings) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public String[] updateSchema(Map<String, Object> settings) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void execute(String[] sql, Map<String, Object> settings) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void clear(Properties settings) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public boolean supportsClear() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public Properties getDatasourceProperties(Map<String, Object> settings) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Properties getDatasourceProperties(Properties current, Map<String, Object> newSettings) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public DatasourceCallback getCallback() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void prepare(Map<String, Object> settings) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public boolean isPostCreateSchema() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public void executePostCreateSchema(Map<String, Object> databaseSettings) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void checkPostCreation(Properties properties) {
+        // TODO Auto-generated method stub
+
+    }
+
+}

--- a/hibernate/h2/src/main/resources/META-INF/services/org.n52.sos.ds.Datasource
+++ b/hibernate/h2/src/main/resources/META-INF/services/org.n52.sos.ds.Datasource
@@ -1,0 +1,1 @@
+org.n52.sos.ds.hibernate.MockDatasource

--- a/misc/conf/datasource.properties.h2.inmemory.template
+++ b/misc/conf/datasource.properties.h2.inmemory.template
@@ -4,10 +4,6 @@ org.n52.sos.ds.Datasource=org.n52.sos.ds.datasource.H2InMemoryDatasource
 # path to mapping files
 HIBERNATE_DIRECTORY=/mapping/core;/mapping/old/observation;/mapping/transactional/mapping/old/spatialFilteringProfile;
 
-# identifier for DAOs and connection provider
-datasource.dao.identifier=hibernate.orm
-connection.provider.identifier=hibernate.orm
-
 # hibernate/h2 inmemory configuration
 hibernate.connection.username=sa
 hibernate.connection.password=

--- a/misc/conf/datasource.properties.mysql.template
+++ b/misc/conf/datasource.properties.mysql.template
@@ -4,10 +4,6 @@ org.n52.sos.ds.Datasource=org.n52.sos.ds.datasource.MySQLDatasource
 # path to mapping files
 HIBERNATE_DIRECTORY=/mapping/core;/mapping/series/observation;/mapping/transactional;/mapping/series/spatialFilteringProfile;
 
-# identifier for DAOs and connection provider
-datasource.dao.identifier=hibernate.orm
-connection.provider.identifier=hibernate.orm
-
 # hibernate/postgres configuration
 
 hibernate.connection.username=mysql

--- a/misc/conf/datasource.properties.oracle.template
+++ b/misc/conf/datasource.properties.oracle.template
@@ -4,10 +4,6 @@ org.n52.sos.ds.Datasource=org.n52.sos.ds.datasource.OracleDatasource
 # path to mapping files
 HIBERNATE_DIRECTORY=/mapping/core;/mapping/series/observation;/mapping/transactional;/mapping/series/spatialFilteringProfile;
 
-# identifier for DAOs and connection provider
-datasource.dao.identifier=hibernate.orm
-connection.provider.identifier=hibernate.orm
-
 # hibernate/postgres configuration
 
 hibernate.connection.username=oracle

--- a/misc/conf/datasource.properties.postgres.template.oldConcept
+++ b/misc/conf/datasource.properties.postgres.template.oldConcept
@@ -4,10 +4,6 @@ org.n52.sos.ds.Datasource=org.n52.sos.ds.datasource.PostgresDatasource
 # path to mapping files
 HIBERNATE_DIRECTORY=/mapping/core;/mapping/old/observation;/mapping/transactional;/mapping/old/spatialFilteringProfile;
 
-# identifier for DAOs and connection provider
-datasource.dao.identifier=hibernate.orm
-connection.provider.identifier=hibernate.orm
-
 # hibernate/postgres configuration
 
 hibernate.connection.username=postgres

--- a/misc/conf/datasource.properties.postgres.template.seriesConcept
+++ b/misc/conf/datasource.properties.postgres.template.seriesConcept
@@ -4,10 +4,6 @@ org.n52.sos.ds.Datasource=org.n52.sos.ds.datasource.PostgresDatasource
 # path to mapping files
 HIBERNATE_DIRECTORY=/mapping/core;/mapping/series/observation;/mapping/transactional;/mapping/series/spatialFilteringProfile;
 
-# identifier for DAOs and connection provider
-datasource.dao.identifier=hibernate.orm
-connection.provider.identifier=hibernate.orm
-
 # hibernate/postgres configuration
 
 hibernate.connection.username=postgres

--- a/misc/conf/datasource.properties.sqlserver.template
+++ b/misc/conf/datasource.properties.sqlserver.template
@@ -4,10 +4,6 @@ org.n52.sos.ds.Datasource=org.n52.sos.ds.datasource.SqlServerDatasource
 # path to mapping files
 HIBERNATE_DIRECTORY=/mapping/core;/mapping/series/observation;/mapping/transactional;/mapping/series/spatialFilteringProfile;
 
-# identifier for DAOs and connection provider
-datasource.dao.identifier=hibernate.orm
-connection.provider.identifier=hibernate.orm
-
 # hibernate/postgres configuration
 
 hibernate.connection.username=sqlserver

--- a/spring/install-controller/src/main/java/org/n52/sos/web/install/InstallFinishController.java
+++ b/spring/install-controller/src/main/java/org/n52/sos/web/install/InstallFinishController.java
@@ -48,8 +48,6 @@ import org.springframework.web.servlet.ModelAndView;
 import org.n52.sos.config.SettingValue;
 import org.n52.sos.ds.ConnectionProviderException;
 import org.n52.sos.ds.Datasource;
-import org.n52.sos.ds.ConnectionProviderIdentificator;
-import org.n52.sos.ds.DatasourceDaoIdentifier;
 import org.n52.sos.exception.ConfigurationException;
 import org.n52.sos.service.Configurator;
 import org.n52.sos.web.ControllerConstants;
@@ -94,8 +92,6 @@ public class InstallFinishController extends AbstractProcessingInstallationContr
         Properties properties = datasource.getDatasourceProperties(c.getDatabaseSettings());
         // save the used datasource class
         properties.put(Datasource.class.getCanonicalName(), datasource.getClass().getCanonicalName());
-        properties.put(ConnectionProviderIdentificator.CONNECTION_PROVIDER_IDENTIFIER, datasource.getConnectionProviderIdentifier());
-        properties.put(DatasourceDaoIdentifier.DATASOURCE_DAO_IDENTIFIER, datasource.getDatasourceDaoIdentifier());
         try {
             if (c.isDropSchema()) {
                 String[] dropSchema = datasource.dropSchema(c.getDatabaseSettings());


### PR DESCRIPTION
Now the SOS uses org.n52.sos.ds.Datasource property to load the defined class, e.g. org.n52.sos.ds.datasource.PostgresDatasource, in the Configurator and call the getter for ConnectionProviderIdentificator and DatasourceDaoIdentifier.
