### PR TITLE
Update build information

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,11 @@
     <inceptionYear>2012</inceptionYear>
     <packaging>pom</packaging>
     <issueManagement>
-        <system>Bugzilla</system>
-        <url>https://bugzilla.52north.org/</url>
+        <system>GitHub issues</system>
+        <url>https://github.com/52North/SOS/issues?state=open</url>
     </issueManagement>
     <ciManagement>
-        <system>hudson</system>
+        <system>Jenkins</system>
         <url>http://build.dev.52north.org/jenkins/job/sos-dev/</url>
     </ciManagement>
     <modules>
@@ -893,6 +893,31 @@
             <goals> <goal>download-licenses</goal> </goals> </execution> </executions>
             </plugin> -->
             <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>git-commit-id</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                        	<dateFormat>yyyy-MM-dd HH:mm:ssZ</dateFormat>
+                            <!-- Only changing prefix since properties conflicts with jgit above
+                            <prefix>git-commit-id</prefix>-->
+                            <!-- We're using a pom in this example
+                            <skipPoms>false</skipPoms>-->
+                            <gitDescribe>
+                                <!-- Faster to get just branch if skip = true -->
+                                <skip>false</skip>
+                            </gitDescribe>
+                            <timestampFormat>{0,date,yyyy-MM-dd HH:mm:ss}</timestampFormat>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
                 <configuration>
@@ -901,6 +926,7 @@
                     <timestampFormat>{0,date,yyyy-MM-dd HH:mm:ss}</timestampFormat>
                     <revisionOnScmFailure>0</revisionOnScmFailure>
                     <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+                    <shortRevisionLength>5</shortRevisionLength>
                 </configuration>
                 <executions>
                     <execution>
@@ -910,7 +936,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
+            </plugin> -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -1073,10 +1099,17 @@
                     </configuration>
                 </plugin>
                 <plugin>
+	                <groupId>pl.project13.maven</groupId>
+	                <artifactId>git-commit-id-plugin</artifactId>
+	                <version>2.1.9</version>
+                </plugin>
+                <!-- 
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
-                    <version>1.2</version>
-                </plugin>
+                    <version>1.3</version>
+                </plugin> 
+                -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>

--- a/spring/common-controller/src/main/java/org/n52/sos/web/MetaDataHandler.java
+++ b/spring/common-controller/src/main/java/org/n52/sos/web/MetaDataHandler.java
@@ -39,7 +39,7 @@ import org.n52.sos.util.AbstractEnumPropertiesFileHandler;
 public class MetaDataHandler extends AbstractEnumPropertiesFileHandler<MetaDataHandler.Metadata> {
 
     public enum Metadata {
-        SVN_VERSION, VERSION, BUILD_DATE, INSTALL_DATE;
+        GIT_BRANCH, GIT_COMMIT, VERSION, BUILD_DATE, INSTALL_DATE;
     }
 
     private static final String PROPERTIES = "/WEB-INF/classes/meta.properties";

--- a/spring/views/src/main/webapp/WEB-INF/views/admin/index.jsp
+++ b/spring/views/src/main/webapp/WEB-INF/views/admin/index.jsp
@@ -62,8 +62,11 @@
         <c:if test="${not empty metadata.VERSION}">
             <p><strong>Version:</strong> ${fn:escapeXml(metadata.VERSION)}</p>
         </c:if>
-        <c:if test="${not empty metadata.SVN_VERSION}">
-            <p><strong>Revision:</strong> ${fn:escapeXml(metadata.SVN_VERSION)}</p>
+        <c:if test="${not empty metadata.GIT_BRANCH}">
+            <p><strong>Branch:</strong> ${fn:escapeXml(metadata.GIT_BRANCH)}</p>
+        </c:if>
+        <c:if test="${not empty metadata.GIT_COMMIT}">
+            <p><strong>Revision:</strong><a href="https://github.com/52North/SOS/commit/${fn:escapeXml(metadata.GIT_COMMIT)}"> ${fn:escapeXml(metadata.GIT_COMMIT)}</a></p>
         </c:if>
         <c:if test="${not empty metadata.BUILD_DATE}">
             <p><strong>Build date:</strong> ${fn:escapeXml(metadata.BUILD_DATE)}</p>

--- a/webapp/src/main/resources/meta.properties
+++ b/webapp/src/main/resources/meta.properties
@@ -1,4 +1,5 @@
 VERSION=${version}
-SVN_VERSION=${buildNumber}
-BUILD_DATE=${timestamp}
-INSTALL_DATE=${timestamp}
+GIT_BRANCH=${git.branch}
+GIT_COMMIT=${git.commit.id}
+BUILD_DATE=${git.build.time}
+INSTALL_DATE=${git.build.time}

--- a/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/src/main/webapp/WEB-INF/web.xml
@@ -4,7 +4,7 @@
 	xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
 	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
 	http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="2.5">
-	<display-name>${project.parent.name}, SVN: ${buildNumber} @ ${timestamp}</display-name>
+	<display-name>${project.parent.name}, Git-Branch '${git.branch}' with state '${git.commit.id}' @ ${git.commit.time}</display-name>
 	<description>This is an OGC SOS.</description>
 
 	<context-param>

--- a/webapp/src/main/webapp/version-info.txt
+++ b/webapp/src/main/webapp/version-info.txt
@@ -2,13 +2,12 @@ General Infos:
 ==============
 project = 52North SOS Reference Implementation (${artifactId})
 version = ${project.version}
-builddate = ${timestamp}
+builddate = ${git.build.time}
 
 Subversion Infos:
 =================
-repository = ${svn.info.repository}
-path = ${svn.info.path}
-revision = ${svn.info.revision}
-mixedRevisions = ${svn.info.mixedRevisions}
-committedRevision = ${svn.info.committedRevision}
-committedDate = ${svn.info.committedDate}
+repository = ${git.repository}
+path = ${git.branch}
+revision = ${git.commit.id}
+lastCommitMessage = ${git.commit.message.short}
+lastCommitDate = ${git.commit.time}


### PR DESCRIPTION
- use maven-git-commit-id-plugin instead of maven-buildnumber-plugin (no installed git client required)
- update names from SVN to GIT
- add branch information
- update issue and ci managment information
