### PR TITLE
Add feature to create geometry from samplingGeometries for featureOfInte...

### DIFF
--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/AbstractObservationDAO.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/AbstractObservationDAO.java
@@ -1161,4 +1161,6 @@ public abstract class AbstractObservationDAO extends TimeCreator {
         }
         return null;
     }
+
+    public abstract List<Geometry> getSamplingGeometries(String feature,  Session session);
 }

--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/ObservationDAO.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/ObservationDAO.java
@@ -41,10 +41,12 @@ import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
 import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.joda.time.DateTime;
 import org.n52.sos.ds.hibernate.entities.AbstractObservation;
+import org.n52.sos.ds.hibernate.entities.AbstractObservationTime;
 import org.n52.sos.ds.hibernate.entities.BlobObservation;
 import org.n52.sos.ds.hibernate.entities.BooleanObservation;
 import org.n52.sos.ds.hibernate.entities.CategoryObservation;
@@ -60,6 +62,8 @@ import org.n52.sos.ds.hibernate.entities.Offering;
 import org.n52.sos.ds.hibernate.entities.Procedure;
 import org.n52.sos.ds.hibernate.entities.SweDataArrayObservation;
 import org.n52.sos.ds.hibernate.entities.TextObservation;
+import org.n52.sos.ds.hibernate.entities.series.Series;
+import org.n52.sos.ds.hibernate.entities.series.SeriesObservationTime;
 import org.n52.sos.ds.hibernate.util.HibernateHelper;
 import org.n52.sos.ds.hibernate.util.ScrollableIterable;
 import org.n52.sos.ogc.gml.time.TimePeriod;
@@ -81,6 +85,8 @@ import org.n52.sos.util.CollectionHelper;
 import org.n52.sos.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.vividsolutions.jts.geom.Geometry;
 
 /**
  * Hibernate data access class for observation
@@ -555,4 +561,13 @@ public class ObservationDAO extends AbstractObservationDAO {
     public SosEnvelope getSpatialFilteringProfileEnvelopeForOfferingId(String offeringID, Session session) throws OwsExceptionReport {
        return getSpatialFilteringProfileEnvelopeForOfferingId(ObservationInfo.class, offeringID, session);
     }
+    
+    @Override
+    public List<Geometry> getSamplingGeometries(String feature, Session session) {
+        Criteria criteria = session.createCriteria(ObservationInfo.class);
+        criteria.createCriteria(AbstractObservation.FEATURE_OF_INTEREST).add(eq(FeatureOfInterest.IDENTIFIER, feature));
+        criteria.addOrder(Order.asc(AbstractObservationTime.PHENOMENON_TIME_START));
+        criteria.setProjection(Projections.property(AbstractObservationTime.SAMPLING_GEOMETRY));
+        return criteria.list();
+    } 
 }

--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/series/SeriesObservationDAO.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/series/SeriesObservationDAO.java
@@ -47,6 +47,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.n52.sos.ds.hibernate.dao.AbstractObservationDAO;
 import org.n52.sos.ds.hibernate.entities.AbstractObservation;
+import org.n52.sos.ds.hibernate.entities.AbstractObservationTime;
 import org.n52.sos.ds.hibernate.entities.FeatureOfInterest;
 import org.n52.sos.ds.hibernate.entities.ObservableProperty;
 import org.n52.sos.ds.hibernate.entities.Observation;
@@ -85,6 +86,8 @@ import org.n52.sos.util.CollectionHelper;
 import org.n52.sos.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.vividsolutions.jts.geom.Geometry;
 
 /**
  * Hibernate data access class for series observations
@@ -795,5 +798,14 @@ public class SeriesObservationDAO extends AbstractObservationDAO {
     @Override
     public SosEnvelope getSpatialFilteringProfileEnvelopeForOfferingId(String offeringID, Session session) throws OwsExceptionReport {
         return getSpatialFilteringProfileEnvelopeForOfferingId(SeriesObservationTime.class, offeringID, session);
-    }    
+    }
+
+    @Override
+    public List<Geometry> getSamplingGeometries(String feature, Session session) {
+        Criteria criteria = session.createCriteria(SeriesObservationTime.class).createAlias(SeriesObservation.SERIES, "s");
+        criteria.createCriteria("s." + Series.FEATURE_OF_INTEREST).add(eq(FeatureOfInterest.IDENTIFIER, feature));
+        criteria.addOrder(Order.asc(AbstractObservationTime.PHENOMENON_TIME_START));
+        criteria.setProjection(Projections.property(AbstractObservationTime.SAMPLING_GEOMETRY));
+        return criteria.list();
+    }  
 }

--- a/hibernate/feature/src/test/java/org/n52/sos/ds/hibernate/HibernateFeatureQueryHandlerTest.java
+++ b/hibernate/feature/src/test/java/org/n52/sos/ds/hibernate/HibernateFeatureQueryHandlerTest.java
@@ -81,7 +81,7 @@ public class HibernateFeatureQueryHandlerTest extends HibernateFeatureQueryHandl
         final String type = SfConstants.SAMPLING_FEAT_TYPE_SF_SAMPLING_POINT;
         FeatureOfInterest feature = create(1, id, null, "name", "url", createFeatureOfInterestType(1, type));
         String version = Sos2Constants.SERVICEVERSION;
-        AbstractFeature result = createSosAbstractFeature(feature, version);
+        AbstractFeature result = createSosAbstractFeature(feature, version, null);
         final AbstractFeature expectedResult =
                 SamplingFeatureBuilder.aSamplingFeature().setFeatureType(type).setIdentifier(id).build();
         assertThat(expectedResult, is(result));
@@ -124,7 +124,7 @@ public class HibernateFeatureQueryHandlerTest extends HibernateFeatureQueryHandl
         GeometryFactory factory = JTSHelper.getGeometryFactoryForSRID(Constants.EPSG_WGS84);
         Geometry geometry = factory.createPoint(randomCoordinate());
         FeatureOfInterest feature = create(1, "id", geometry, "name", "url", createFeatureOfInterestType(1, "type"));
-        AbstractFeature sosFeature = createSosAbstractFeature(feature, Sos2Constants.SERVICEVERSION);
+        AbstractFeature sosFeature = createSosAbstractFeature(feature, Sos2Constants.SERVICEVERSION, null);
 
         assertThat(GeometryHandler.getInstance().isAxisOrderSwitchRequired(Constants.EPSG_WGS84), is(true));
         assertThat(sosFeature, is(notNullValue()));
@@ -159,7 +159,7 @@ public class HibernateFeatureQueryHandlerTest extends HibernateFeatureQueryHandl
         assertThat(GeometryHandler.getInstance().isAxisOrderSwitchRequired(2181), is(false));
 
         FeatureOfInterest feature = create(1, "id", geometry, "name", "url", createFeatureOfInterestType(1, "type"));
-        AbstractFeature sosFeature = createSosAbstractFeature(feature, Sos2Constants.SERVICEVERSION);
+        AbstractFeature sosFeature = createSosAbstractFeature(feature, Sos2Constants.SERVICEVERSION, null);
 
         assertThat(GeometryHandler.getInstance().isAxisOrderSwitchRequired(Constants.EPSG_WGS84), is(true));
         assertThat(sosFeature, is(notNullValue()));


### PR DESCRIPTION
...rest if the featureOfInterest geometry == null:
- If the featureOfInterest geometry == null the SOS tries to query the samplingGeometries from the relatedObservations, ordered by phenomenonTime.
- If samplingGeometries are available, a gml:Point (one  samplingGeometry) or a gml:Curve (several samplingGeometries)  is created.
- If a two successive geometries have the same coordinates, the subsequent geometry is omitted.
