### PR TITLE
Fix for DescribeSensor requests with non SensorML 1.0.1 procedureDescrip...

### DIFF
--- a/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/DescribeSensorDAO.java
+++ b/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/DescribeSensorDAO.java
@@ -199,13 +199,7 @@ public class DescribeSensorDAO extends AbstractDescribeSensorDAO {
      * @return All possible procedure description formats
      */
     private Set<String> getPossibleProcedureDescriptionFormats(String procedureDescriptionFormat) {
-        Set<String> possibleFormats = Sets.newHashSet();
-        possibleFormats.add(procedureDescriptionFormat);
-        if (SensorMLConstants.SENSORML_OUTPUT_FORMAT_MIME_TYPE.equalsIgnoreCase(procedureDescriptionFormat)) {
-            possibleFormats.add(SensorMLConstants.SENSORML_OUTPUT_FORMAT_URL);
-        } else if (SensorMLConstants.SENSORML_OUTPUT_FORMAT_URL.equalsIgnoreCase(procedureDescriptionFormat)) {
-            possibleFormats.add(SensorMLConstants.SENSORML_OUTPUT_FORMAT_MIME_TYPE);
-        }
+        Set<String> possibleFormats = checkForUrlVsMimeType(procedureDescriptionFormat);
         String procedureDescriptionFormatMatchingString =
                 getProcedureDescriptionFormatMatchingString(procedureDescriptionFormat);
         for (Entry<ServiceOperatorKey, Set<String>> pdfByServiceOperatorKey : CodingRepository.getInstance()
@@ -234,10 +228,22 @@ public class DescribeSensorDAO extends AbstractDescribeSensorDAO {
         // match against lowercase string, ignoring whitespace
         return procedureDescriptionFormat.toLowerCase().replaceAll("\\s", "");
     }
+    
+    private Set<String> checkForUrlVsMimeType(String procedureDescriptionFormat) {
+    	 Set<String> possibleFormats = Sets.newHashSet();
+    	 possibleFormats.add(procedureDescriptionFormat);
+         if (SensorMLConstants.SENSORML_OUTPUT_FORMAT_MIME_TYPE.equalsIgnoreCase(procedureDescriptionFormat)) {
+             possibleFormats.add(SensorMLConstants.SENSORML_OUTPUT_FORMAT_URL);
+         } else if (SensorMLConstants.SENSORML_OUTPUT_FORMAT_URL.equalsIgnoreCase(procedureDescriptionFormat)) {
+             possibleFormats.add(SensorMLConstants.SENSORML_OUTPUT_FORMAT_MIME_TYPE);
+         }
+         return possibleFormats;
+    }
+    
 
     private SosProcedureDescription convertProcedureDescription(SosProcedureDescription procedureDescription,
             DescribeSensorRequest request) throws CodedException {
-        if (!getPossibleProcedureDescriptionFormats(request.getProcedureDescriptionFormat()).contains(procedureDescription.getDescriptionFormat())) {
+        if (!checkForUrlVsMimeType(procedureDescription.getDescriptionFormat()).contains(request.getProcedureDescriptionFormat())) {
             Converter<SosProcedureDescription, SosProcedureDescription> converter =
                     ConverterRepository.getInstance().getConverter(procedureDescription.getDescriptionFormat(),
                             request.getProcedureDescriptionFormat());


### PR DESCRIPTION
Fix for DescribeSensor requests with non SensorML 1.0.1 procedureDescriptionFormat (e.g. Hydrology Profile):
- Before the check in the convertProcedureDescription  method was invalid.
