### PR TITLE
Fix for # 101 SOS 1.0.0 GetObservation SOAP request

### DIFF
--- a/core/api/src/main/java/org/n52/sos/request/operator/AbstractRequestOperator.java
+++ b/core/api/src/main/java/org/n52/sos/request/operator/AbstractRequestOperator.java
@@ -64,7 +64,6 @@ import org.n52.sos.service.Configurator;
 import org.n52.sos.service.operator.ServiceOperatorRepository;
 import org.n52.sos.service.profile.Profile;
 import org.n52.sos.util.CollectionHelper;
-import org.n52.sos.util.http.MediaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -507,15 +506,15 @@ public abstract class AbstractRequestOperator<D extends OperationDAO, Q extends 
             // don't normalize response format with MediaType parsing here, that's the job of the v1 decoders
             obsResponse.setResponseFormat(obsRequest.getResponseFormat());
 
-            MediaType contentTypeFromResponseFormat = null;
-            try {
-                contentTypeFromResponseFormat = MediaType.parse(obsRequest.getResponseFormat()).withoutParameters();
-            } catch (IllegalArgumentException iae) {
-                LOGGER.debug("Requested responseFormat {} is not a MediaType", obsRequest.getResponseFormat());
-            }
-            if (contentTypeFromResponseFormat != null) {
-                obsResponse.setContentType(contentTypeFromResponseFormat);
-            }
+//            MediaType contentTypeFromResponseFormat = null;
+//            try {
+//                contentTypeFromResponseFormat = MediaType.parse(obsRequest.getResponseFormat()).withoutParameters();
+//            } catch (IllegalArgumentException iae) {
+//                LOGGER.debug("Requested responseFormat {} is not a MediaType", obsRequest.getResponseFormat());
+//            }
+//            if (contentTypeFromResponseFormat != null) {
+//                obsResponse.setContentType(contentTypeFromResponseFormat);
+//            }
         }
     }
 


### PR DESCRIPTION
- Problem: SOS 1.0.0 GetObservation SOAP request fails because the contentType is set in the AbstractRequestOperator from the requested responseFormat if it is a MimeType.
- Solution: remove the contentType setting from responseFormat.
