### PR TITLE
Fix #109: First position is missing in the featuerOfInterest geometry if...

### DIFF
--- a/hibernate/feature/src/main/java/org/n52/sos/ds/hibernate/HibernateFeatureQueryHandler.java
+++ b/hibernate/feature/src/main/java/org/n52/sos/ds/hibernate/HibernateFeatureQueryHandler.java
@@ -475,15 +475,12 @@ public class HibernateFeatureQueryHandler implements FeatureQueryHandler, Hibern
                     List<Coordinate> coordinates = Lists.newLinkedList();
                     Geometry lastGeoemtry = null;
                     for (Geometry geometry : geometries) {
-                        if (lastGeoemtry == null) {
+                        if (lastGeoemtry == null || !geometry.equalsTopo(lastGeoemtry)) {
+                        	coordinates.add(GeometryHandler.getInstance().switchCoordinateAxisOrderIfNeeded(geometry).getCoordinate());
                             lastGeoemtry = geometry;
-                        }
-                        if (geometry.getSRID() != srid) {
-                           srid = geometry.getSRID();
-                        }
-                        if (!geometry.equalsTopo(lastGeoemtry)) {
-                            coordinates.add(GeometryHandler.getInstance().switchCoordinateAxisOrderIfNeeded(geometry).getCoordinate());
-                            lastGeoemtry = geometry;
+                            if (geometry.getSRID() != srid) {
+                                srid = geometry.getSRID();
+                             }
                         }
                     }
                     Geometry geom = null;


### PR DESCRIPTION
... generated from samplingGeometries
- Problem: The first coordinate was not added to the coordinate list.
- Solution: Add the first coordinate to the list.
