### PR TITLE
Fix checkSchemaCreation during install

### DIFF
--- a/hibernate/datasource/oracle/src/main/java/org/n52/sos/ds/datasource/OracleDatasource.java
+++ b/hibernate/datasource/oracle/src/main/java/org/n52/sos/ds/datasource/OracleDatasource.java
@@ -151,13 +151,14 @@ public class OracleDatasource extends AbstractHibernateFullDBDatasource {
      * {@link Datasource#checkSchemaCreation(Map)} for testing
      */
     void doCheckSchemaCreation(String schema, Statement stmt) throws SQLException {
-        schema = schema == null ? "" : schema + ".";
+        final String schemaPrefix = schema == null ? "" : "\"" + schema + "\"."; 
+        final String testTable = schemaPrefix + "sos_test"; 
         final String command =
-                String.format("BEGIN\n" + "  BEGIN\n" + "    EXECUTE IMMEDIATE 'DROP TABLE \"%1$ssos_test\"';\n"
+                String.format("BEGIN\n" + "  BEGIN\n" + "    EXECUTE IMMEDIATE 'DROP TABLE %1$s';\n"
                         + "  EXCEPTION\n" + "    WHEN OTHERS THEN\n" + "      IF SQLCODE != -942 THEN\n"
                         + "        RAISE;\n" + "      END IF;\n" + "  END;\n"
-                        + "  EXECUTE IMMEDIATE 'CREATE TABLE \"%1$ssos_test\" (id integer NOT NULL)';\n"
-                        + "  EXECUTE IMMEDIATE 'DROP TABLE \"%1$ssos_test\"';\n" + "END;\n", schema);
+                        + "  EXECUTE IMMEDIATE 'CREATE TABLE %1$s (id integer NOT NULL)';\n"
+                        + "  EXECUTE IMMEDIATE 'DROP TABLE %1$s';\n" + "END;\n", testTable);
         stmt.execute(command);
     }
 

--- a/hibernate/datasource/postgres/src/main/java/org/n52/sos/ds/datasource/AbstractPostgresDatasource.java
+++ b/hibernate/datasource/postgres/src/main/java/org/n52/sos/ds/datasource/AbstractPostgresDatasource.java
@@ -109,12 +109,13 @@ public abstract class AbstractPostgresDatasource extends AbstractHibernateFullDB
         try {
             conn = openConnection(settings);
             stmt = conn.createStatement();
-            String schema = (String) settings.get(createSchemaDefinition().getKey());
-            schema = schema == null ? "" : "." + schema;
+            final String schema = (String) settings.get(createSchemaDefinition().getKey());
+            final String schemaPrefix = schema == null ? "" : "\"" + schema + "\".";
+            final String testTable = schemaPrefix + "sos_installer_test_table";
             final String command =
-                    String.format("BEGIN; " + "DROP TABLE IF EXISTS \"%1$ssos_installer_test_table\"; "
-                            + "CREATE TABLE \"%1$ssos_installer_test_table\" (id integer NOT NULL); "
-                            + "DROP TABLE \"%1$ssos_installer_test_table\"; " + "END;", schema);
+                    String.format("BEGIN; " + "DROP TABLE IF EXISTS %1$s; "
+                            + "CREATE TABLE %1$s (id integer NOT NULL); "
+                            + "DROP TABLE %1$s; " + "END;", testTable);
             stmt.execute(command);
             return true;
         } catch (SQLException e) {

--- a/hibernate/datasource/sqlserver/src/main/java/org/n52/sos/ds/datasource/AbstractSqlServerDatasource.java
+++ b/hibernate/datasource/sqlserver/src/main/java/org/n52/sos/ds/datasource/AbstractSqlServerDatasource.java
@@ -157,12 +157,13 @@ public abstract class AbstractSqlServerDatasource extends AbstractHibernateFullD
         try {
             conn = openConnection(settings);
             stmt = conn.createStatement();
-            String schema = (String) settings.get(createSchemaDefinition().getKey());
-            schema = schema == null ? "" : "." + schema;
+            final String schema = (String) settings.get(createSchemaDefinition().getKey());
+            final String schemaPrefix = schema == null ? "" : "\"" + schema + "\".";
+            final String testTable = schemaPrefix + "sos_installer_test_table";
             final String command =
-                    String.format("BEGIN; " + "DROP TABLE IF EXISTS \"%1$ssos_installer_test_table\"; "
-                            + "CREATE TABLE \"%1$ssos_installer_test_table\" (id integer NOT NULL); "
-                            + "DROP TABLE \"%1$ssos_installer_test_table\"; " + "END;", schema);
+                    String.format("BEGIN; " + "IF (OBJECT_ID('%1$s') >0 ) DROP TABLE %1$s; "
+                            + "CREATE TABLE %1$s (id integer NOT NULL); "
+                            + "DROP TABLE %1$s; " + "END;", testTable);
             stmt.execute(command);
             return true;
         } catch (SQLException e) {

--- a/spring/install-controller/src/main/java/org/n52/sos/web/install/InstallDatasourceController.java
+++ b/spring/install-controller/src/main/java/org/n52/sos/web/install/InstallDatasourceController.java
@@ -93,7 +93,10 @@ public class InstallDatasourceController extends AbstractProcessingInstallationC
                             }
                         }
                     }
-                    datasource.checkSchemaCreation(c.getDatabaseSettings());
+                    if (!datasource.checkSchemaCreation(c.getDatabaseSettings())) {
+                        throw new InstallationSettingsError(c, String.format(
+                                ErrorMessages.COULD_NOT_CREATE_SOS_TABLES, "schema creation test table"));                        
+                    }
                 } else if (!alreadyExistent) {
                     throw new InstallationSettingsError(c, ErrorMessages.NO_TABLES_AND_SHOULD_NOT_CREATE);
                 } else {


### PR DESCRIPTION
The results of checkSchemaCreation weren't actually being checked during install. MySQL didn't have a legitimate checkSchemaCreation implementation, and most of the other datasources had small problems with their implementations. This commit causes an install error to be thrown if checkSchemaCreation returns false and fixed checkSchemaCreation implementation problems. Tested against all relevant database platforms (Postgres, MySQL, Oracle, and SQL Server).
