### PR TITLE
Fix for 'cannot access javax.servlet.ServletContextListener'

### DIFF
--- a/core/sqlite-config/pom.xml
+++ b/core/sqlite-config/pom.xml
@@ -31,13 +31,17 @@
             <artifactId>test</artifactId>
             <scope>test</scope>
         </dependency>
-             <dependency>
+        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-spatial</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>servlet-api</artifactId>
+		</dependency>
     </dependencies>
-<build>
+    <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/hibernate/common/pom.xml
+++ b/hibernate/common/pom.xml
@@ -28,6 +28,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>servlet-api</artifactId>
+            <scope>test</scope>
+		</dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>coding-sensorML-v101</artifactId>
             <scope>test</scope>

--- a/hibernate/dao/pom.xml
+++ b/hibernate/dao/pom.xml
@@ -44,6 +44,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>servlet-api</artifactId>
+            <scope>test</scope>
+		</dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>coding-sensorML-v101</artifactId>
             <scope>test</scope>

--- a/hibernate/feature/pom.xml
+++ b/hibernate/feature/pom.xml
@@ -38,5 +38,10 @@
             <artifactId>api</artifactId>
             <classifier>tests</classifier>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/hibernate/h2/pom.xml
+++ b/hibernate/h2/pom.xml
@@ -51,7 +51,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.opengeo</groupId>


### PR DESCRIPTION
either introduced by the update of jdk (8u11 -> 8u20) or maven (3.2.2 -> 3.2.3)
