### PR TITLE
Check if the execution of the samplingGeometry extent query should be executed

### DIFF
--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/AbstractObservationDAO.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/AbstractObservationDAO.java
@@ -1163,4 +1163,19 @@ public abstract class AbstractObservationDAO extends TimeCreator {
     }
 
     public abstract List<Geometry> getSamplingGeometries(String feature,  Session session);
+
+    /**
+     * Check if the observation table contains samplingGeometries with values
+     * 
+     * @param session
+     *            Hibernate session
+     * @return <code>true</code>, if the observation table contains samplingGeometries with values
+     */
+    public boolean containsSamplingGeometries(Session session) {
+        Criteria criteria = getDefaultObservationInfoCriteria(session);
+        criteria.add(Restrictions.isNotNull(AbstractObservation.SAMPLING_GEOMETRY));
+        criteria.setProjection(Projections.rowCount());
+        LOGGER.debug("QUERY containsSamplingGeometries(): {}", HibernateHelper.getSqlString(criteria));
+        return (Long) criteria.uniqueResult() > 0;
+    }
 }

--- a/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/cache/base/OfferingCacheUpdateTask.java
+++ b/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/cache/base/OfferingCacheUpdateTask.java
@@ -82,17 +82,24 @@ public class OfferingCacheUpdateTask extends AbstractThreadableDatasourceCacheUp
 
     private boolean obsConstSupported;
     
+    private boolean hasSamplingGeometry;
+    
     /**
-     * Constructor. Note: never pass in Hibernate objects that have been loaded by a session in a different thread
+     * Constructor. Note: never pass in Hibernate objects that have been loaded
+     * by a session in a different thread
      * 
      * @param dsOfferingId
      *            Offering identifier
      * @param observationConstellatinInfos
-     *            Observation Constellation info collection, passed in from parent update if supported
+     *            Observation Constellation info collection, passed in from  parent update if supported
+     * @param hasSamplingGeometry
+     *            Indicator to execute or not the extent query for the Spatial Filtering Profile
      */
-    public OfferingCacheUpdateTask(String dsOfferingId, Collection<ObservationConstellationInfo> observationConstellationInfos) {
+    public OfferingCacheUpdateTask(String dsOfferingId,
+            Collection<ObservationConstellationInfo> observationConstellationInfos, boolean hasSamplingGeometry) {
         this.offeringId = dsOfferingId;
         this.observationConstellationInfos = observationConstellationInfos;
+        this.hasSamplingGeometry = hasSamplingGeometry;
     }
 
     protected void getOfferingInformationFromDbAndAddItToCacheMaps(Session session) throws OwsExceptionReport {
@@ -273,8 +280,10 @@ public class OfferingCacheUpdateTask extends AbstractThreadableDatasourceCacheUp
             getCache().setSpatialFilteringProfileEnvelopeForOffering(prefixedOfferingId,
                     spatialFilteringProfileDAO.getEnvelopeForOfferingId(offeringID, session));
         } else {
-            getCache().setSpatialFilteringProfileEnvelopeForOffering(prefixedOfferingId,
-                  DaoFactory.getInstance().getObservationDAO(session).getSpatialFilteringProfileEnvelopeForOfferingId(offeringID, session));
+            if (hasSamplingGeometry) {
+                getCache().setSpatialFilteringProfileEnvelopeForOffering(prefixedOfferingId,
+                      DaoFactory.getInstance().getObservationDAO(session).getSpatialFilteringProfileEnvelopeForOfferingId(offeringID, session));
+            }
         }
     }
 


### PR DESCRIPTION
(improve performance):
- Add pre-query to check if the observation table contains not null samplingGeometries.
- If only samplingGeometries with null value are contained, the extent query is not executed during the offering cache update.
