### PR TITLE
When you stop the SOS, the following statement is logged to the catalina...

### DIFF
--- a/core/api/src/main/java/org/n52/sos/util/GeometryHandler.java
+++ b/core/api/src/main/java/org/n52/sos/util/GeometryHandler.java
@@ -44,6 +44,7 @@ import org.geotools.factory.Hints;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.factory.AbstractAuthorityFactory;
+import org.geotools.referencing.factory.DeferredAuthorityFactory;
 import org.n52.sos.config.SettingsManager;
 import org.n52.sos.config.annotation.Configurable;
 import org.n52.sos.config.annotation.Setting;
@@ -153,11 +154,16 @@ public class GeometryHandler implements Cleanupable, EpsgConstants {
     
     @Override
     public void cleanup() {
-        if (getCrsAuthorityFactory() != null && getCrsAuthorityFactory() instanceof AbstractAuthorityFactory) {
-            try {
-                ((AbstractAuthorityFactory)getCrsAuthorityFactory()).dispose();
-            } catch (FactoryException fe) {
-                LOGGER.error("Error while GeometryHandler clean up", fe);
+        if (getCrsAuthorityFactory() != null) {
+            if (getCrsAuthorityFactory() instanceof DeferredAuthorityFactory) {
+                DeferredAuthorityFactory.exit();
+            }
+            if (getCrsAuthorityFactory() instanceof AbstractAuthorityFactory) {
+                try {
+                    ((AbstractAuthorityFactory)getCrsAuthorityFactory()).dispose();
+                } catch (FactoryException fe) {
+                    LOGGER.error("Error while GeometryHandler clean up", fe);
+                }
             }
         }
     }


### PR DESCRIPTION
....out file:

... The web application [/52n-sos-webapp] appears to have started a TimerThread named [GT authority factory disposer] via the java.util.Timer API but has failed to stop it. ...
This Commit solves this problem by calling "DeferredAuthorityFactory.exit();".
