### PR TITLE
Fix repository definitions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1307,13 +1307,18 @@
             </snapshots>
         </repository>
         <repository>
-            <id>opengeo</id>
-            <name>OpenGeo repository</name>
-            <url>http://repo.opengeo.org</url>
+            <id>osgeo</id>
+            <name>Open Source Geospatial Foundation Repository</name>
+            <url>http://download.osgeo.org/webdav/geotools/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
         </repository>
+        <repository>
+			<id>boundless</id>
+			<name>Boundless, formerly OpenGeo</name>
+			<url>http://repo.boundlessgeo.com/main/</url>
+		</repository>
     </repositories>
     <profiles>
         <profile>


### PR DESCRIPTION
- Add GeoTools repository: http://download.osgeo.org/webdav/geotools/
- Fix OpenGeo, now called Boundless, repository: http://repo.boundlessgeo.com/main/
