### PR TITLE
Add check for href value to sampledFeature insertion.

### DIFF
--- a/hibernate/feature/src/main/java/org/n52/sos/ds/hibernate/HibernateFeatureQueryHandler.java
+++ b/hibernate/feature/src/main/java/org/n52/sos/ds/hibernate/HibernateFeatureQueryHandler.java
@@ -49,7 +49,6 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.spatial.criterion.SpatialProjections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.n52.sos.config.annotation.Configurable;
 import org.n52.sos.ds.FeatureQueryHandler;
 import org.n52.sos.ds.FeatureQueryHandlerQueryObject;
@@ -70,6 +69,7 @@ import org.n52.sos.exception.ows.concrete.NotYetSupportedException;
 import org.n52.sos.i18n.I18NDAORepository;
 import org.n52.sos.i18n.LocalizedString;
 import org.n52.sos.i18n.metadata.I18NFeatureMetadata;
+import org.n52.sos.ogc.OGCConstants;
 import org.n52.sos.ogc.filter.SpatialFilter;
 import org.n52.sos.ogc.gml.AbstractFeature;
 import org.n52.sos.ogc.gml.CodeWithAuthority;
@@ -494,10 +494,12 @@ public class HibernateFeatureQueryHandler implements FeatureQueryHandler, Hibern
                 Set<FeatureOfInterest> parents =
                         Sets.newHashSetWithExpectedSize(samplingFeature.getSampledFeatures().size());
                 for (AbstractFeature sampledFeature : samplingFeature.getSampledFeatures()) {
-                    if (sampledFeature instanceof SamplingFeature) {
-                        parents.add(insertFeatureOfInterest((SamplingFeature) sampledFeature, session));
-                    } else {
-                        parents.add(insertFeatureOfInterest(new SamplingFeature(sampledFeature.getIdentifierCodeWithAuthority()), session));
+                    if (!OGCConstants.UNKNOWN.equals(sampledFeature.getIdentifierCodeWithAuthority().getValue())) {
+                        if (sampledFeature instanceof SamplingFeature) {
+                            parents.add(insertFeatureOfInterest((SamplingFeature) sampledFeature, session));
+                        } else {
+                            parents.add(insertFeatureOfInterest(new SamplingFeature(sampledFeature.getIdentifierCodeWithAuthority()), session));
+                        }
                     }
                 }
                 ((TFeatureOfInterest) feature).setParents(parents);


### PR DESCRIPTION
 If the href value is http://www.opengis.net/def/nil/OGC/0/unknown, no sampledFeature with identifier http://www.opengis.net/def/nil/OGC/0/unknown is inserted.
