### PR TITLE
Add support for inserting observation collection in REST

### DIFF
--- a/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/encode/RestEncoder.java
+++ b/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/encode/RestEncoder.java
@@ -46,6 +46,7 @@ import org.n52.sos.binding.rest.resources.capabilities.CapabilitiesGetResponse;
 import org.n52.sos.binding.rest.resources.features.FeatureByIdResponse;
 import org.n52.sos.binding.rest.resources.features.FeaturesGetEncoder;
 import org.n52.sos.binding.rest.resources.features.FeaturesResponse;
+import org.n52.sos.binding.rest.resources.observations.ObservationsCollectionPostResponse;
 import org.n52.sos.binding.rest.resources.observations.ObservationsDeleteEncoder;
 import org.n52.sos.binding.rest.resources.observations.ObservationsDeleteRespone;
 import org.n52.sos.binding.rest.resources.observations.ObservationsGetByIdResponse;
@@ -128,7 +129,8 @@ public class RestEncoder implements Encoder<ServiceResponse, RestResponse> {
             {
                 return new CapabilitiesGetEncoder();
             } 
-            else if (restResponse instanceof ObservationsPostResponse) 
+            else if (restResponse instanceof ObservationsPostResponse || 
+                    restResponse instanceof ObservationsCollectionPostResponse) 
             {
                 return new ObservationsPostEncoder();
             } 

--- a/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/resources/observations/ObservationsCollectionPostRequest.java
+++ b/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/resources/observations/ObservationsCollectionPostRequest.java
@@ -33,7 +33,7 @@ import net.opengis.om.x20.OMObservationType;
 import org.n52.sos.request.InsertObservationRequest;
 
 /**
- * @author <a href="mailto:e.h.juerrens@52north.org">Eike Hinderk J&uuml;rrens</a>
+ * @author <a href="mailto:ydamigos@iccs.gr">Yannis Damigos</a>
  *
  */
 public class ObservationsCollectionPostRequest implements IObservationsRequest {

--- a/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/resources/observations/ObservationsCollectionPostRequest.java
+++ b/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/resources/observations/ObservationsCollectionPostRequest.java
@@ -28,41 +28,34 @@
  */
 package org.n52.sos.binding.rest.resources.observations;
 
-import java.io.IOException;
+import net.opengis.om.x20.OMObservationType;
 
-import org.apache.xmlbeans.XmlException;
-import org.n52.sos.binding.rest.requests.RequestHandler;
-import org.n52.sos.binding.rest.requests.RestRequest;
-import org.n52.sos.binding.rest.requests.RestResponse;
-import org.n52.sos.ogc.ows.OwsExceptionReport;
+import org.n52.sos.request.InsertObservationRequest;
 
 /**
  * @author <a href="mailto:e.h.juerrens@52north.org">Eike Hinderk J&uuml;rrens</a>
  *
  */
-public class ObservationsRequestHandler extends RequestHandler {
+public class ObservationsCollectionPostRequest implements IObservationsRequest {
 
-    @Override
-    public RestResponse handleRequest(RestRequest request) throws OwsExceptionReport, XmlException, IOException
+    private InsertObservationRequest insertObservationRequest;
+    
+    private OMObservationType[] xb_OMObservationCollection;
+
+    public ObservationsCollectionPostRequest(InsertObservationRequest insertObservationRequest,
+            OMObservationType[] xb_OMObservationCollection) {
+        this.insertObservationRequest = insertObservationRequest;
+        this.xb_OMObservationCollection = xb_OMObservationCollection;
+    }
+    
+    public InsertObservationRequest getInsertObservationRequest()
     {
-        if (isGetRequest(request)) {
-            return new ObservationsGetRequestHandler().handleRequest(request);
-
-        } else if (request instanceof ObservationsPostRequest || request instanceof ObservationsCollectionPostRequest){
-            //return new ObservationsPostRequestHandler().handleRequest((ObservationsPostRequest)request);
-            return new ObservationsPostRequestHandler().handleRequest(request);
-
-        } else if (request instanceof ObservationsDeleteRequest) {
-            return new ObservationsDeleteRequestHandler().handleRequest((ObservationsDeleteRequest)request);
-            
-        } 
-        throw logRequestTypeNotSupportedByThisHandlerAndCreateException(request,this.getClass().getName());
+        return insertObservationRequest;
     }
 
-    private boolean isGetRequest(RestRequest request)
+    public OMObservationType[] getXb_OMObservationCollection()
     {
-        return request instanceof ObservationsSearchRequest ||
-                request instanceof ObservationsGetRequest;
+        return xb_OMObservationCollection;
     }
 
 }

--- a/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/resources/observations/ObservationsCollectionPostResponse.java
+++ b/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/resources/observations/ObservationsCollectionPostResponse.java
@@ -33,7 +33,7 @@ import net.opengis.om.x20.OMObservationType;
 import org.n52.sos.binding.rest.requests.RestResponse;
 
 /**
- * @author <a href="mailto:e.h.juerrens@52north.org">Eike Hinderk J&uuml;rrens</a>
+ * @author <a href="mailto:ydamigos@iccs.gr">Yannis Damigos</a>
  *
  */
 public class ObservationsCollectionPostResponse implements RestResponse {

--- a/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/resources/observations/ObservationsCollectionPostResponse.java
+++ b/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/resources/observations/ObservationsCollectionPostResponse.java
@@ -28,41 +28,34 @@
  */
 package org.n52.sos.binding.rest.resources.observations;
 
-import java.io.IOException;
+import net.opengis.om.x20.OMObservationType;
 
-import org.apache.xmlbeans.XmlException;
-import org.n52.sos.binding.rest.requests.RequestHandler;
-import org.n52.sos.binding.rest.requests.RestRequest;
 import org.n52.sos.binding.rest.requests.RestResponse;
-import org.n52.sos.ogc.ows.OwsExceptionReport;
 
 /**
  * @author <a href="mailto:e.h.juerrens@52north.org">Eike Hinderk J&uuml;rrens</a>
  *
  */
-public class ObservationsRequestHandler extends RequestHandler {
+public class ObservationsCollectionPostResponse implements RestResponse {
 
-    @Override
-    public RestResponse handleRequest(RestRequest request) throws OwsExceptionReport, XmlException, IOException
-    {
-        if (isGetRequest(request)) {
-            return new ObservationsGetRequestHandler().handleRequest(request);
+    private String observationIdentifier;
+    
+    private OMObservationType[] xb_OMObservationCollection;
 
-        } else if (request instanceof ObservationsPostRequest || request instanceof ObservationsCollectionPostRequest){
-            //return new ObservationsPostRequestHandler().handleRequest((ObservationsPostRequest)request);
-            return new ObservationsPostRequestHandler().handleRequest(request);
-
-        } else if (request instanceof ObservationsDeleteRequest) {
-            return new ObservationsDeleteRequestHandler().handleRequest((ObservationsDeleteRequest)request);
-            
-        } 
-        throw logRequestTypeNotSupportedByThisHandlerAndCreateException(request,this.getClass().getName());
+    public ObservationsCollectionPostResponse(String identifier,
+            OMObservationType[] xb_OMObservationCollection) {
+        this.observationIdentifier = identifier;
+        this.xb_OMObservationCollection = xb_OMObservationCollection;
     }
 
-    private boolean isGetRequest(RestRequest request)
+    public String getObservationIdentifier()
     {
-        return request instanceof ObservationsSearchRequest ||
-                request instanceof ObservationsGetRequest;
+        return observationIdentifier;
+    }
+
+    public OMObservationType[] getXb_OMObservationCollection()
+    {
+        return xb_OMObservationCollection;
     }
 
 }

--- a/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/resources/observations/ObservationsDecoder.java
+++ b/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/resources/observations/ObservationsDecoder.java
@@ -37,7 +37,10 @@ import javax.servlet.http.HttpServletRequest;
 
 import net.opengis.gml.x32.CodeWithAuthorityType;
 import net.opengis.om.x20.OMObservationType;
+import net.opengis.sos.x20.GetObservationResponseType.ObservationData;
 import net.opengis.sosREST.x10.LinkType;
+import net.opengis.sosREST.x10.ObservationCollectionDocument;
+import net.opengis.sosREST.x10.ObservationCollectionType;
 import net.opengis.sosREST.x10.ObservationDocument;
 import net.opengis.sosREST.x10.ObservationType;
 
@@ -185,6 +188,56 @@ public class ObservationsDecoder extends ResourceDecoder {
                 insertObservationRequest.addObservation(sosObs);
                 
                 return new ObservationsPostRequest(insertObservationRequest,xb_OMObservation);
+            } else if (requestDoc instanceof ObservationCollectionDocument) {
+                ObservationCollectionDocument xb_ObservationCollectionRestDoc = (ObservationCollectionDocument) requestDoc;
+                ObservationCollectionType xb_ObservationCollectionRest = xb_ObservationCollectionRestDoc.getObservationCollection();
+                ObservationType[] xb_ObservationArrayRest = new ObservationType[xb_ObservationCollectionRest.sizeOfObservationArray()];
+                for (int i = 0; i < xb_ObservationCollectionRest.sizeOfObservationArray(); i++) {
+                    xb_ObservationArrayRest[i] = xb_ObservationCollectionRest.getObservationArray(i);
+                }
+                InsertObservationRequest insertObservationRequest = new InsertObservationRequest();
+                insertObservationRequest.setService(bindingConstants.getSosService());
+                insertObservationRequest.setVersion(bindingConstants.getSosVersion());
+                List<String> offeringIds = new ArrayList<String>();
+                OMObservationType[] xb_OMObservationCollection = new OMObservationType[xb_ObservationArrayRest.length];
+                for (int j = 0; j < xb_ObservationArrayRest.length; j++) {
+                    xb_OMObservationCollection[j] = xb_ObservationArrayRest[j].getOMObservation();
+                    // 1 check for gml:identifier
+                    if (!xb_OMObservationCollection[j].isSetIdentifier()) {
+                        // 1.1 if not available set to newly generated UUID 
+                        CodeWithAuthorityType xb_gmlIdentifier = CodeWithAuthorityType.Factory.newInstance();
+                        xb_gmlIdentifier.setCodeSpace(UUID.class.getName());
+                        xb_gmlIdentifier.setStringValue(UUID.randomUUID().toString());
+                        xb_OMObservationCollection[j].setIdentifier(xb_gmlIdentifier);
+                    }
+                    
+                    // 2 get offering link
+                    LinkType[] xb_links = xb_ObservationArrayRest[j].getLinkArray();
+                    for (LinkType xb_Link : xb_links) {
+                        if (isOfferingLink(xb_Link)) {
+                            String href = xb_Link.getHref();
+                            int lastSlashIndex = href.lastIndexOf("/");
+                            String offeringId = href.substring(lastSlashIndex+1);
+                            offeringIds.add(offeringId);
+                        }
+                    }
+                    
+                    // 2.1 clean links to resources like procedure and feature
+                    if (isProcedureReferenced(xb_OMObservationCollection[j]) && 
+                            isProcedureReferencePoitingToMe(xb_OMObservationCollection[j])) {
+                        resetProcedureReference(xb_OMObservationCollection[j]);
+                    }
+                    if (isFeatureReferenced(xb_OMObservationCollection[j]) &&
+                            isFeatureReferencePointingToMe(xb_OMObservationCollection[j])) {
+                        resetFeatureOfInterstReference(xb_OMObservationCollection[j]);
+                    }
+                    
+                    // 3 build insert observation request
+                    insertObservationRequest.setOfferings(offeringIds);
+                    OmObservation sosObs = createSosObservationFromOMObservation(xb_OMObservationCollection[j]);
+                    insertObservationRequest.addObservation(sosObs);
+                }
+                return new ObservationsCollectionPostRequest(insertObservationRequest, xb_OMObservationCollection);
             }
         }
         String errorMsg = String.format(bindingConstants.getErrorMessageHttpMethodNotAllowedForResource(),

--- a/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/resources/observations/ObservationsPostEncoder.java
+++ b/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/resources/observations/ObservationsPostEncoder.java
@@ -29,11 +29,21 @@
 package org.n52.sos.binding.rest.resources.observations;
 
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import net.opengis.om.x20.OMObservationType;
+import net.opengis.sos.x20.GetObservationResponseType.ObservationData;
+import net.opengis.sosREST.x10.ObservationCollectionDocument;
+import net.opengis.sosREST.x10.ObservationCollectionType;
 import net.opengis.sosREST.x10.ObservationDocument;
+import net.opengis.sosREST.x10.ObservationType;
 
 import org.n52.sos.binding.rest.requests.RestResponse;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
 import org.n52.sos.response.ServiceResponse;
+import org.n52.sos.util.SosHelper;
 import org.n52.sos.util.http.HTTPStatus;
 
 
@@ -60,6 +70,29 @@ public class ObservationsPostEncoder extends AObservationsEncoder {
                     observationsPostResponse.getObservationIdentifier(),
                     bindingConstants.getResourceObservations());
             
+            return response;
+        }
+        if (restResponse != null && restResponse instanceof ObservationsCollectionPostResponse) {
+            ObservationsCollectionPostResponse observationsCollectionPostResponse = (ObservationsCollectionPostResponse) restResponse;
+            ObservationCollectionDocument xb_ObservationCollectionDoc = ObservationCollectionDocument.Factory.newInstance();
+            ObservationCollectionType xb_ObservationCollection = xb_ObservationCollectionDoc.addNewObservationCollection();
+            ArrayList<ObservationType> xb_observationList = new ArrayList<ObservationType>();
+            Map<String,String> inDocumentReferenceToFeatureId = new HashMap<String, String>();
+            for (OMObservationType xb_OMobservation : observationsCollectionPostResponse.getXb_OMObservationCollection())
+            {
+                SosHelper.checkFreeMemory();
+                ObservationType xb_restObservation = createRestObservationFromOMObservation(ObservationType.Factory.newInstance(),
+                        xb_OMobservation, inDocumentReferenceToFeatureId);
+                xb_observationList.add(xb_restObservation);
+            }
+            ObservationType[] xb_obsTypeArray = xb_observationList.toArray(new ObservationType[xb_observationList.size()]);
+            xb_ObservationCollection.setObservationArray(xb_obsTypeArray);
+
+            ServiceResponse response = createServiceResponseFromXBDocument(
+                    xb_ObservationCollectionDoc,
+                    bindingConstants.getResourceObservations(),
+                    HTTPStatus.OK, true, false);
+
             return response;
         }
         return null;

--- a/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/resources/observations/ObservationsPostRequestHandler.java
+++ b/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/resources/observations/ObservationsPostRequestHandler.java
@@ -63,6 +63,22 @@ public class ObservationsPostRequestHandler extends RequestHandler {
                         ((ObservationsPostRequest) req).getXb_OMObservation());
             } 
         }
+        if (req != null && req instanceof ObservationsCollectionPostRequest) {
+            InsertObservationRequest ioReq = ((ObservationsCollectionPostRequest) req).getInsertObservationRequest();
+            
+            // 2 handle core response
+            XmlObject xb_InsertObservationResponse = executeSosRequest(ioReq);
+            
+            if (xb_InsertObservationResponse instanceof InsertObservationResponseDocument) {
+                // 3 return response
+                // no interesting content, just check the class to be sure that the insertion was successful
+                // the restful response requires the link to the newly created observation
+                // FIXME we are always using only the first observation in the list without checking
+                return new ObservationsCollectionPostResponse(
+                        ioReq.getObservations().get(0).getIdentifier().getValue(),
+                        ((ObservationsCollectionPostRequest) req).getXb_OMObservationCollection());
+            } 
+        }
         throw logRequestTypeNotSupportedByThisHandlerAndCreateException(req,this.getClass().getName());
     }
 

--- a/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/resources/observations/ObservationsPostRequestHandler.java
+++ b/bindings/rest/code/src/main/java/org/n52/sos/binding/rest/resources/observations/ObservationsPostRequestHandler.java
@@ -75,7 +75,7 @@ public class ObservationsPostRequestHandler extends RequestHandler {
                 // the restful response requires the link to the newly created observation
                 // FIXME we are always using only the first observation in the list without checking
                 return new ObservationsCollectionPostResponse(
-                        ioReq.getObservations().get(0).getIdentifier().getValue(),
+                        ioReq.getObservations().get(0).getIdentifierCodeWithAuthority().getValue(),
                         ((ObservationsCollectionPostRequest) req).getXb_OMObservationCollection());
             } 
         }


### PR DESCRIPTION
The following patches add support for inserting multiple observations using the REST interface.