### PR TITLE
Fix/ip with port proxy chain

### DIFF
--- a/core/api/src/main/java/org/n52/sos/util/net/ProxyChain.java
+++ b/core/api/src/main/java/org/n52/sos/util/net/ProxyChain.java
@@ -30,9 +30,11 @@ package org.n52.sos.util.net;
 
 import java.util.List;
 
+import org.n52.sos.util.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -133,7 +135,7 @@ public class ProxyChain {
                 List<IPAddress> chain = Lists
                         .newArrayListWithExpectedSize(split.length);
                 for (String splitted : split) {
-                    chain.add(new IPAddress(splitted.trim()));
+                    chain.add(getIPAddress(splitted));
                 }
                 return Optional.of(new ProxyChain(chain));
             }
@@ -142,5 +144,10 @@ public class ProxyChain {
                      header, e);
         }
         return Optional.absent();
+    }
+    
+    @VisibleForTesting
+    static IPAddress getIPAddress(String address) {
+        return new IPAddress(address.split(Constants.COLON_STRING)[0].trim());
     }
 }

--- a/core/api/src/test/java/org/n52/sos/util/net/ProxyChainTest.java
+++ b/core/api/src/test/java/org/n52/sos/util/net/ProxyChainTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2012-2015 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *     - Apache License, version 2.0
+ *     - Apache Software License, version 1.0
+ *     - GNU Lesser General Public License, version 3
+ *     - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *     - Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public
+ * License version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ */
+package org.n52.sos.util.net;
+
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+
+public class ProxyChainTest {
+    
+    private String ip = "192.168.52.123";
+            
+    private String port = ":50684";
+    
+    private String ipPort = ip + ":" + port;
+    
+    @Test 
+    public void shouldHandleIp() {
+        assertEquals("192.168.52.123", ProxyChain.getIPAddress(ip).asString());
+     }
+    
+    @Test 
+    public void shouldHandleIpWithPort() {
+        assertEquals("192.168.52.123", ProxyChain.getIPAddress(ipPort).asString());
+     }
+
+}


### PR DESCRIPTION
Fix issue during parsing of the x-forwarded. If the IP address contains a valid optional port, the parser threw an IllegalArgumentException. Now the parser supports the optional port.