### PR TITLE
Fix for issue #168 Laxer checking of output format

### DIFF
--- a/coding/sensorML-v101/src/main/java/org/n52/sos/convert/SensorMLUrlMimeTypeConverter.java
+++ b/coding/sensorML-v101/src/main/java/org/n52/sos/convert/SensorMLUrlMimeTypeConverter.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2012-2015 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *     - Apache License, version 2.0
+ *     - Apache Software License, version 1.0
+ *     - GNU Lesser General Public License, version 3
+ *     - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *     - Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public
+ * License version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ */
+package org.n52.sos.convert;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.n52.sos.convert.Converter;
+import org.n52.sos.convert.ConverterException;
+import org.n52.sos.convert.ConverterKeyType;
+import org.n52.sos.ogc.sensorML.SensorMLConstants;
+import org.n52.sos.ogc.sos.SosProcedureDescription;
+import org.n52.sos.util.CollectionHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Joiner;
+
+/**
+ * Converter for SensorML 1.0.1 URL to SensorML 1.0.1 MimeType
+ * 
+ * @author Carsten Hollmann <c.hollmann@52north.org>
+ * @since 4.2.0
+ *
+ */
+public class SensorMLUrlMimeTypeConverter implements Converter<SosProcedureDescription, SosProcedureDescription> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SensorMLUrlMimeTypeConverter.class);
+
+    private static final List<ConverterKeyType> CONVERTER_KEY_TYPES = CollectionHelper.list(
+            new ConverterKeyType(SensorMLConstants.SENSORML_OUTPUT_FORMAT_MIME_TYPE, SensorMLConstants.SENSORML_OUTPUT_FORMAT_URL), 
+            new ConverterKeyType(SensorMLConstants.SENSORML_OUTPUT_FORMAT_URL, SensorMLConstants.SENSORML_OUTPUT_FORMAT_MIME_TYPE));
+
+    public SensorMLUrlMimeTypeConverter() {
+        LOGGER.debug("Converter for the following keys initialized successfully: {}!",
+                Joiner.on(", ").join(CONVERTER_KEY_TYPES));
+    }
+
+    @Override
+    public List<ConverterKeyType> getConverterKeyTypes() {
+        return Collections.unmodifiableList(CONVERTER_KEY_TYPES);
+    }
+
+    @Override
+    public SosProcedureDescription convert(SosProcedureDescription objectToConvert) throws ConverterException {
+        return objectToConvert;
+    }
+
+}

--- a/coding/sensorML-v101/src/main/java/org/n52/sos/encode/SensorMLEncoderv101.java
+++ b/coding/sensorML-v101/src/main/java/org/n52/sos/encode/SensorMLEncoderv101.java
@@ -1410,6 +1410,7 @@ public class SensorMLEncoderv101 extends AbstractXmlEncoder<Object> implements P
                 // update the name of present field
                 if (field.getElement() instanceof SweText) {
                     final SweText sweText = (SweText) field.getElement();
+                    Set<SweText> fieldsToRemove = Sets.newHashSet();
                     for (SweText sweTextField : sweTextFieldSet) {
                         if (sweText.getValue().equals(sweTextField.getValue())) {
                             if (sweTextField.isSetName()) {
@@ -1418,7 +1419,12 @@ public class SensorMLEncoderv101 extends AbstractXmlEncoder<Object> implements P
                                 field.setName(fieldName);
                             }
                             // we don't need to add it any more
-                            sweTextFieldSet.remove(sweTextField);
+                            fieldsToRemove.add(sweTextField);
+                        }
+                    }
+                    if (CollectionHelper.isNotEmpty(fieldsToRemove)) {
+                        for (SweText st : fieldsToRemove) {
+                            sweTextFieldSet.remove(st);
                         }
                     }
                 }

--- a/coding/sensorML-v101/src/main/resources/META-INF/services/org.n52.sos.convert.Converter
+++ b/coding/sensorML-v101/src/main/resources/META-INF/services/org.n52.sos.convert.Converter
@@ -1,0 +1,1 @@
+org.n52.sos.convert.SensorMLUrlMimeTypeConverter

--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/ObservationDAO.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/ObservationDAO.java
@@ -559,10 +559,12 @@ public class ObservationDAO extends AbstractObservationDAO {
        return getSpatialFilteringProfileEnvelopeForOfferingId(ObservationInfo.class, offeringID, session);
     }
     
+    @SuppressWarnings("unchecked")
     @Override
     public List<Geometry> getSamplingGeometries(String feature, Session session) {
         Criteria criteria = session.createCriteria(ObservationInfo.class);
         criteria.createCriteria(AbstractObservation.FEATURE_OF_INTEREST).add(eq(FeatureOfInterest.IDENTIFIER, feature));
+        criteria.add(Restrictions.isNotNull(AbstractObservationTime.SAMPLING_GEOMETRY));
         criteria.addOrder(Order.asc(AbstractObservationTime.PHENOMENON_TIME_START));
         criteria.setProjection(Projections.property(AbstractObservationTime.SAMPLING_GEOMETRY));
         return criteria.list();

--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/series/SeriesObservationDAO.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/series/SeriesObservationDAO.java
@@ -908,6 +908,7 @@ public class SeriesObservationDAO extends AbstractObservationDAO {
         Criteria criteria =
                 session.createCriteria(SeriesObservationTime.class).createAlias(SeriesObservation.SERIES, "s");
         criteria.createCriteria("s." + Series.FEATURE_OF_INTEREST).add(eq(FeatureOfInterest.IDENTIFIER, feature));
+        criteria.add(Restrictions.isNotNull(AbstractObservationTime.SAMPLING_GEOMETRY));
         criteria.addOrder(Order.asc(AbstractObservationTime.PHENOMENON_TIME_START));
         criteria.setProjection(Projections.property(AbstractObservationTime.SAMPLING_GEOMETRY));
         LOGGER.debug("QUERY getSamplingGeometries(feature): {}", HibernateHelper.getSqlString(criteria));

--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/util/procedure/HibernateProcedureConverter.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/util/procedure/HibernateProcedureConverter.java
@@ -304,7 +304,10 @@ public class HibernateProcedureConverter implements HibernateSqlQueryConstants {
             Converter<SosProcedureDescription, Object> converter =
                     ConverterRepository.getInstance()
                     .getConverter(fromFormat, toFormat);
-            return converter.convert(description);
+            if (converter != null) {
+                return converter.convert(description);
+            }
+            throw new ConverterException(String.format("No converter available to convert from '%s' to '%s'", fromFormat, toFormat));
         } catch (ConverterException ce) {
             throw new NoApplicableCodeException().causedBy(ce)
                     .withMessage("Error while processing data for DescribeSensor document!");

--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/util/procedure/enrich/RelatedProceduresEnrichment.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/util/procedure/enrich/RelatedProceduresEnrichment.java
@@ -159,7 +159,7 @@ public class RelatedProceduresEnrichment extends ProcedureDescriptionEnrichment 
                         converter.createSosProcedureDescriptionFromValidProcedureTime(
                                 child, childVpt, getVersion(), getLocale(), getSession());
                 childProcedures.add(childDescription);                
-            } else {
+            } else  if  (child != null) {
                 //no matching child validProcedureTime, generate the procedure description
                 SosProcedureDescription childDescription = converter.createSosProcedureDescription(
                         child, procedureDescriptionFormat, getVersion(), procedureCache, getLocale(), getSession());

--- a/webapp/src/main/resources/logback.xml
+++ b/webapp/src/main/resources/logback.xml
@@ -44,6 +44,5 @@
 
 	<root level="INFO">
 		<appender-ref ref="FILE" />
-		<appender-ref ref="STDOUT" />
 	</root>
 </configuration>


### PR DESCRIPTION
Both are now supported:

* ``text/xml; subtype="sensorML/1.0.1"`` 
* ``text/xml;subtype="sensorML/1.0.1"`` 

This pull request contains also some further improvements:
- no default STDOUT logging, only in the 52n-sos-webapp.log files
- null checks in DescribeSensor processing