### PR TITLE
Fix for issue #167: Improve error message when requesting empty time period

### DIFF
--- a/core/api/src/main/java/org/n52/sos/ogc/sos/SosConstants.java
+++ b/core/api/src/main/java/org/n52/sos/ogc/sos/SosConstants.java
@@ -163,7 +163,7 @@ public interface SosConstants {
     }
 
     enum Filter {
-        ValueReference;
+        ValueReference, TimePeriod, TimeInstant;
     }
 
     /**


### PR DESCRIPTION
Now the exceptions message contains the reason for the exception. The begin/end time of a time period are equal or the being time is after the end time.