### PR TITLE
Use setting's default value if missing from configuration.db

### DIFF
--- a/core/api/src/main/java/org/n52/sos/config/AbstractSettingsManager.java
+++ b/core/api/src/main/java/org/n52/sos/config/AbstractSettingsManager.java
@@ -229,7 +229,12 @@ public abstract class AbstractSettingsManager extends SettingsManager {
         HashSet<SettingDefinition<?, ?>> nullValues = new HashSet<SettingDefinition<?, ?>>(getSettingDefinitions());
         nullValues.removeAll(settingsByDefinition.keySet());
         for (SettingDefinition<?, ?> s : nullValues) {
-            settingsByDefinition.put(s, null);
+            if (s.hasDefaultValue()) {
+                settingsByDefinition.put(s, getSettingFactory().newSettingValue(s, s.getDefaultValue().toString()));
+            } else {
+                LOG.warn("No value or default value for '{}' found; using null.", s.getKey());
+                settingsByDefinition.put(s, getSettingFactory().newSettingValue(s, null));
+            }
         }
         return settingsByDefinition;
     }


### PR DESCRIPTION
This commit changes AbstractSettingsManager to use a setting's default value (if available) if the setting isn't present in configuration.db, falling back to null if not default is available. Currently nulls are used whenever a setting isn't found in configuration.db.