### PR TITLE
Fix for GetResult with not published series values in the result

### DIFF
--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/series/AbstractSeriesDAO.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/series/AbstractSeriesDAO.java
@@ -188,8 +188,7 @@ public abstract class AbstractSeriesDAO {
     }
     
     public Criteria getSeriesCriteria(String observedProperty, Collection<String> features, Session session) {
-        final Criteria c = session.createCriteria(getSeriesClass()).setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY);
-        c.add(Restrictions.eq(Series.DELETED, false));
+        final Criteria c = getDefaultSeriesCriteria(session);
         if (CollectionHelper.isNotEmpty(features)) {
             addFeatureOfInterestToCriteria(c, features);
         }


### PR DESCRIPTION
Use getDefaultSeriesCriteria instead of creating own Criteria in the method. Method is uses in GetResultDAO and without this fix GetResult did not consider the published flag.