### PR TITLE
Fix #264 : SOS throws a NPE in SensorML 1.0.1 decoder if characteristics/capabilities element has no AbstractDataRecord element

### DIFF
--- a/coding/sensorML-v101/src/main/java/org/n52/sos/decode/SensorMLDecoderV101.java
+++ b/coding/sensorML-v101/src/main/java/org/n52/sos/decode/SensorMLDecoderV101.java
@@ -467,19 +467,32 @@ public class SensorMLDecoderV101 extends AbstractSensorMLDecoder {
             throws OwsExceptionReport {
         final List<SmlCharacteristics> sosCharacteristicsList =
                 new ArrayList<SmlCharacteristics>(characteristicsArray.length);
-        final SmlCharacteristics sosCharacteristics = new SmlCharacteristics();
         for (final Characteristics xbCharacteristics : characteristicsArray) {
-            final Object decodedObject = CodingHelper.decodeXmlElement(xbCharacteristics.getAbstractDataRecord());
-            if (decodedObject instanceof DataRecord) {
-                sosCharacteristics.setDataRecord((DataRecord) decodedObject);
-            } else {
-                throw new InvalidParameterValueException()
-                        .at(XmlHelper.getLocalName(xbCharacteristics))
-                        .withMessage(
-                                "Error while parsing the characteristics of the SensorML (the characteristics' data record is not of type DataRecordPropertyType)!");
-            }
+        	final SmlCharacteristics sosCharacteristics = new SmlCharacteristics();
+        	if (xbCharacteristics.isSetName()) {
+        		sosCharacteristics.setName(xbCharacteristics.getName());
+        	}
+        	if (xbCharacteristics.isSetAbstractDataRecord()) {
+        		final Object decodedObject = CodingHelper.decodeXmlElement(xbCharacteristics.getAbstractDataRecord());
+                if (decodedObject instanceof DataRecord) {
+                    sosCharacteristics.setDataRecord((DataRecord) decodedObject);
+                } else {
+                    throw new InvalidParameterValueException()
+                            .at(XmlHelper.getLocalName(xbCharacteristics))
+                            .withMessage(
+                                    "Error while parsing the characteristics of the SensorML (the characteristics' data record is not of type DataRecordPropertyType)!");
+                }
+        	} else if (xbCharacteristics.isSetHref()) {
+        		sosCharacteristics.setHref(xbCharacteristics.getHref());
+        		if (xbCharacteristics.isSetTitle()) {
+        			sosCharacteristics.setTitle(xbCharacteristics.getTitle());
+        		}
+         	}
+        	if (sosCharacteristics.isSetName()) {
+        		sosCharacteristicsList.add(sosCharacteristics);
+        	}
         }
-        sosCharacteristicsList.add(sosCharacteristics);
+        
         return sosCharacteristicsList;
     }
 
@@ -499,25 +512,37 @@ public class SensorMLDecoderV101 extends AbstractSensorMLDecoder {
     private void parseCapabilities(final AbstractProcess abstractProcess, final Capabilities[] capabilitiesArray)
             throws OwsExceptionReport {
         for (final Capabilities xbcaps : capabilitiesArray) {
-            final Object o = CodingHelper.decodeXmlElement(xbcaps.getAbstractDataRecord());
-            if (o instanceof DataRecord) {
-                final DataRecord record = (DataRecord) o;
-                final SmlCapabilities caps = new SmlCapabilities();
-                caps.setDataRecord(record).setName(xbcaps.getName());
-                abstractProcess.addCapabilities(caps);
-                // check if this capabilities is insertion metadata
-                if (SensorMLConstants.ELEMENT_NAME_OFFERINGS.equals(caps.getName())) {
-                    abstractProcess.addOfferings(SosOffering.fromSet(caps.getDataRecord().getSweAbstractSimpleTypeFromFields(SweText.class)));
-                } else if (SensorMLConstants.ELEMENT_NAME_PARENT_PROCEDURES.equals(caps.getName())) {
-                    abstractProcess.addParentProcedures(parseCapabilitiesMetadata(caps, xbcaps).keySet());
-                } else if (SensorMLConstants.ELEMENT_NAME_FEATURES_OF_INTEREST.equals(caps.getName())) {
-                    abstractProcess.addFeaturesOfInterest(parseCapabilitiesMetadata(caps, xbcaps).keySet());
-                }
-            } else {
-                throw new InvalidParameterValueException().at(XmlHelper.getLocalName(xbcaps)).withMessage(
-                        "Error while parsing the capabilities of " + "the SensorML (the capabilities data record "
-                                + "is not of type DataRecordPropertyType)!");
-            }
+        	final SmlCapabilities caps = new SmlCapabilities();
+        	if (xbcaps.isSetName()) {
+				caps.setName(xbcaps.getName());
+			}
+        	if (xbcaps.isSetAbstractDataRecord()) {
+        		 final Object o = CodingHelper.decodeXmlElement(xbcaps.getAbstractDataRecord());
+                 if (o instanceof DataRecord) {
+                     final DataRecord record = (DataRecord) o;
+                     caps.setDataRecord(record).setName(xbcaps.getName());
+                     // check if this capabilities is insertion metadata
+                     if (SensorMLConstants.ELEMENT_NAME_OFFERINGS.equals(caps.getName())) {
+                         abstractProcess.addOfferings(SosOffering.fromSet(caps.getDataRecord().getSweAbstractSimpleTypeFromFields(SweText.class)));
+                     } else if (SensorMLConstants.ELEMENT_NAME_PARENT_PROCEDURES.equals(caps.getName())) {
+                         abstractProcess.addParentProcedures(parseCapabilitiesMetadata(caps, xbcaps).keySet());
+                     } else if (SensorMLConstants.ELEMENT_NAME_FEATURES_OF_INTEREST.equals(caps.getName())) {
+                         abstractProcess.addFeaturesOfInterest(parseCapabilitiesMetadata(caps, xbcaps).keySet());
+                     }
+                 } else {
+                     throw new InvalidParameterValueException().at(XmlHelper.getLocalName(xbcaps)).withMessage(
+                             "Error while parsing the capabilities of " + "the SensorML (the capabilities data record "
+                                     + "is not of type DataRecordPropertyType)!");
+                 }
+			} else if (xbcaps.isSetHref()) {
+				caps.setHref(xbcaps.getHref());
+				if (xbcaps.isSetTitle()) {
+					caps.setTitle(xbcaps.getTitle());
+				}
+			}
+        	if (caps.isSetName()) {
+        		abstractProcess.addCapabilities(caps);
+        	}
         }
     }
 

--- a/coding/sensorML-v101/src/main/java/org/n52/sos/encode/SensorMLEncoderv101.java
+++ b/coding/sensorML-v101/src/main/java/org/n52/sos/encode/SensorMLEncoderv101.java
@@ -689,6 +689,11 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
             final XmlObject substituteElement =
                     XmlHelper.substituteElement(xbCapabilities.addNewAbstractDataRecord(), encodedDataRecord);
             substituteElement.set(encodedDataRecord);
+        } else if (capabilities.isSetHref()) {
+        	xbCapabilities.setHref(capabilities.getHref());
+        	if (capabilities.isSetTitle()) {
+        		xbCapabilities.setTitle(capabilities.getTitle());
+        	}
         }
         return xbCapabilities;
     }
@@ -852,9 +857,12 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
         final List<Characteristics> characteristicsList =
                 Lists.newArrayListWithExpectedSize(smlCharacteristics.size());
         for (final SmlCharacteristics sosSMLCharacteristics : smlCharacteristics) {
+        	final Characteristics xbCharacteristics =
+                    Characteristics.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+        	 if (sosSMLCharacteristics.isSetName()) {
+             	xbCharacteristics.setName(sosSMLCharacteristics.getName());
+            }
             if (sosSMLCharacteristics.isSetAbstractDataRecord()) {
-                final Characteristics xbCharacteristics =
-                        Characteristics.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
                 if (sosSMLCharacteristics.getDataRecord() instanceof SweSimpleDataRecord) {
                     final SimpleDataRecordType xbSimpleDataRecord =
                             (SimpleDataRecordType) xbCharacteristics.addNewAbstractDataRecord().substitute(
@@ -880,8 +888,16 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
                                     "The SWE characteristics type '%s' is not supported by this SOS for SensorML characteristics!",
                                     sosSMLCharacteristics.getDataRecord().getClass().getName());
                 }
-                characteristicsList.add(xbCharacteristics);
+            } else if (sosSMLCharacteristics.isSetHref()) {
+            	if (sosSMLCharacteristics.isSetName()) {
+            		xbCharacteristics.setName(sosSMLCharacteristics.getName());
+                }
+            	xbCharacteristics.setHref(sosSMLCharacteristics.getHref());
+            	if (sosSMLCharacteristics.isSetTitle()) {
+            		xbCharacteristics.setTitle(sosSMLCharacteristics.getTitle());
+            	}
             }
+            characteristicsList.add(xbCharacteristics);
         }
         return characteristicsList.toArray(new Characteristics[characteristicsList.size()]);
     }

--- a/coding/sensorML-v101/src/main/java/org/n52/sos/encode/SensorMLEncoderv101.java
+++ b/coding/sensorML-v101/src/main/java/org/n52/sos/encode/SensorMLEncoderv101.java
@@ -96,7 +96,6 @@ import org.n52.sos.service.ServiceConstants.SupportedTypeKey;
 import org.n52.sos.util.CodingHelper;
 import org.n52.sos.util.CollectionHelper;
 import org.n52.sos.util.XmlHelper;
-import org.n52.sos.util.XmlOptionsHelper;
 import org.n52.sos.util.http.HTTPStatus;
 import org.n52.sos.util.http.MediaType;
 import org.n52.sos.w3c.SchemaLocation;
@@ -165,20 +164,20 @@ import net.opengis.swe.x101.VectorType;
 public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
     private static final Logger LOGGER = LoggerFactory.getLogger(SensorMLEncoderv101.class);
 
-    private static final Map<SupportedTypeKey, Set<String>> SUPPORTED_TYPES = singletonMap(
-            SupportedTypeKey.ProcedureDescriptionFormat, (Set<String>) ImmutableSet.of(
-                    SensorMLConstants.SENSORML_OUTPUT_FORMAT_URL, SensorMLConstants.SENSORML_CONTENT_TYPE.toString()));
+    private static final Map<SupportedTypeKey, Set<String>> SUPPORTED_TYPES =
+            singletonMap(SupportedTypeKey.ProcedureDescriptionFormat,
+                    (Set<String>) ImmutableSet.of(SensorMLConstants.SENSORML_OUTPUT_FORMAT_URL,
+                            SensorMLConstants.SENSORML_CONTENT_TYPE.toString()));
 
     private static final Map<String, ImmutableMap<String, Set<String>>> SUPPORTED_PROCEDURE_DESCRIPTION_FORMATS =
-            ImmutableMap.of(
-                    SosConstants.SOS,
-                    ImmutableMap
-                            .<String, Set<String>> builder()
+            ImmutableMap.of(SosConstants.SOS,
+                    ImmutableMap.<String, Set<String>> builder()
                             .put(Sos2Constants.SERVICEVERSION,
                                     ImmutableSet.of(SensorMLConstants.SENSORML_OUTPUT_FORMAT_URL))
                             .put(Sos1Constants.SERVICEVERSION,
-                                    ImmutableSet.of(SensorMLConstants.SENSORML_OUTPUT_FORMAT_MIME_TYPE)).build());
-    
+                                    ImmutableSet.of(SensorMLConstants.SENSORML_OUTPUT_FORMAT_MIME_TYPE))
+                            .build());
+
     @SuppressWarnings("unchecked")
     private static final Set<EncoderKey> ENCODER_KEYS = union(
             encoderKeysForElements(SensorMLConstants.NS_SML, SosProcedureDescription.class, AbstractSensorML.class),
@@ -186,8 +185,8 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
                     AbstractSensorML.class));
 
     public SensorMLEncoderv101() {
-        LOGGER.debug("Encoder for the following keys initialized successfully: {}!", Joiner.on(", ")
-                .join(ENCODER_KEYS));
+        LOGGER.debug("Encoder for the following keys initialized successfully: {}!",
+                Joiner.on(", ").join(ENCODER_KEYS));
     }
 
     @Override
@@ -266,7 +265,8 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
         }
     }
 
-    protected XmlObject createSensorDescriptionFromString(final AbstractSensorML sensorDesc) throws OwsExceptionReport {
+    protected XmlObject createSensorDescriptionFromString(final AbstractSensorML sensorDesc)
+            throws OwsExceptionReport {
         try {
             final XmlObject xmlObject = XmlObject.Factory.parse(sensorDesc.getSensorDescriptionXmlString());
             if (xmlObject instanceof SensorMLDocument) {
@@ -322,8 +322,7 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
         // TODO Review: System -> return doc; ProcessModel -> return type
         if (sensorDesc instanceof System) {
             final System system = (System) sensorDesc;
-            final SystemDocument xbSystemDoc =
-                    SystemDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+            final SystemDocument xbSystemDoc = SystemDocument.Factory.newInstance(getOptions());
             final SystemType xbSystem = xbSystemDoc.addNewSystem();
             addAbstractProcessValues(xbSystem, system);
             addSystemValues(xbSystem, system);
@@ -331,44 +330,35 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
         } else if (sensorDesc instanceof ProcessModel) {
             // TODO: set values
             final ProcessModel processModel = (ProcessModel) sensorDesc;
-            final ProcessModelDocument xbProcessModelDoc =
-                    ProcessModelDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+            final ProcessModelDocument xbProcessModelDoc = ProcessModelDocument.Factory.newInstance(getOptions());
             final ProcessModelType xbProcessModel = xbProcessModelDoc.addNewProcessModel();
             addAbstractProcessValues(xbProcessModel, processModel);
             addProcessModelValues(xbProcessModel, processModel);
             return xbProcessModel;
         } else {
-            throw new NoApplicableCodeException().withMessage(
-                    "The sensor description type is not supported by this service!").setStatus(
-                    HTTPStatus.INTERNAL_SERVER_ERROR);
+            throw new NoApplicableCodeException()
+                    .withMessage("The sensor description type is not supported by this service!")
+                    .setStatus(HTTPStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
     protected SensorMLDocument createSensorMLDescription(final SensorML smlSensorDesc) throws OwsExceptionReport {
-        final SensorMLDocument sensorMLDoc =
-                SensorMLDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+        final SensorMLDocument sensorMLDoc = SensorMLDocument.Factory.newInstance(getOptions());
         final net.opengis.sensorML.x101.SensorMLDocument.SensorML xbSensorML = sensorMLDoc.addNewSensorML();
         xbSensorML.setVersion(SensorMLConstants.VERSION_V101);
         if (smlSensorDesc.isSetMembers()) {
             for (final AbstractProcess sml : smlSensorDesc.getMembers()) {
                 if (sml instanceof System) {
-                    final SystemType xbSystem =
-                            (SystemType) xbSensorML
-                                    .addNewMember()
-                                    .addNewProcess()
-                                    .substitute(new QName(SensorMLConstants.NS_SML, SensorMLConstants.EN_SYSTEM),
-                                            SystemType.type);
+                    final SystemType xbSystem = (SystemType) xbSensorML.addNewMember().addNewProcess().substitute(
+                            new QName(SensorMLConstants.NS_SML, SensorMLConstants.EN_SYSTEM), SystemType.type);
                     final System smlSystem = (System) sml;
                     addAbstractProcessValues(xbSystem, smlSystem);
                     addSystemValues(xbSystem, smlSystem);
                 } else if (sml instanceof ProcessModel) {
                     final ProcessModelType xbProcessModel =
-                            (ProcessModelType) xbSensorML
-                                    .addNewMember()
-                                    .addNewProcess()
-                                    .substitute(
-                                            new QName(SensorMLConstants.NS_SML, SensorMLConstants.EN_PROCESS_MODEL),
-                                            ProcessModelType.type);
+                            (ProcessModelType) xbSensorML.addNewMember().addNewProcess().substitute(
+                                    new QName(SensorMLConstants.NS_SML, SensorMLConstants.EN_PROCESS_MODEL),
+                                    ProcessModelType.type);
                     final ProcessModel smlProcessModel = (ProcessModel) sml;
                     addAbstractProcessValues(xbProcessModel, smlProcessModel);
                     addProcessModelValues(xbProcessModel, smlProcessModel);
@@ -643,7 +633,7 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
 
     private boolean isContained(final ResponsibleParty responsibleParty,
             final Set<ResponsibleParty> mergedResponsibleParties) {
-        final XmlOptions xmlOptions = XmlOptionsHelper.getInstance().getXmlOptions();
+        final XmlOptions xmlOptions = getOptions();
         for (final ResponsibleParty responsibleParty2 : mergedResponsibleParties) {
             if (isIdentical(responsibleParty, xmlOptions, responsibleParty2)) {
                 return true;
@@ -653,7 +643,7 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
     }
 
     private boolean isContained(final Person person, final Set<Person> mergedPersons) {
-        final XmlOptions xmlOptions = XmlOptionsHelper.getInstance().getXmlOptions();
+        final XmlOptions xmlOptions = getOptions();
         for (final Person anotherPerson : mergedPersons) {
             if (isIdentical(person, xmlOptions, anotherPerson)) {
                 return true;
@@ -678,8 +668,7 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
     }
 
     private Capabilities createCapability(final SmlCapabilities capabilities) throws OwsExceptionReport {
-        final Capabilities xbCapabilities =
-                Capabilities.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+        final Capabilities xbCapabilities = Capabilities.Factory.newInstance(getOptions());
         if (capabilities.isSetName()) {
             xbCapabilities.setName(capabilities.getName());
         }
@@ -690,10 +679,10 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
                     XmlHelper.substituteElement(xbCapabilities.addNewAbstractDataRecord(), encodedDataRecord);
             substituteElement.set(encodedDataRecord);
         } else if (capabilities.isSetHref()) {
-        	xbCapabilities.setHref(capabilities.getHref());
-        	if (capabilities.isSetTitle()) {
-        		xbCapabilities.setTitle(capabilities.getTitle());
-        	}
+            xbCapabilities.setHref(capabilities.getHref());
+            if (capabilities.isSetTitle()) {
+                xbCapabilities.setTitle(capabilities.getTitle());
+            }
         }
         return xbCapabilities;
     }
@@ -745,8 +734,8 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
         if (abstractProcess.isSetPhenomenon()) {
             for (SmlIo<?> output : abstractProcess.getOutputs()) {
                 if (abstractProcess.hasPhenomenonFor(output.getIoValue().getDefinition())) {
-                    output.getIoValue().setName(
-                            abstractProcess.getPhenomenonFor(output.getIoValue().getDefinition()).getName());
+                    output.getIoValue()
+                            .setName(abstractProcess.getPhenomenonFor(output.getIoValue().getDefinition()).getName());
                 }
             }
         }
@@ -768,8 +757,7 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
     }
 
     private MethodPropertyType createMethod(final ProcessMethod method) throws CodedException {
-        final MethodPropertyType xbMethod =
-                MethodPropertyType.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+        final MethodPropertyType xbMethod = MethodPropertyType.Factory.newInstance(getOptions());
         if (method.isSetHref()) {
             xbMethod.setHref(method.getHref());
             if (method.isSetTitle()) {
@@ -785,8 +773,8 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
                 xbRulesDefinition.addNewDescription().setStringValue(method.getRulesDefinition().getDescription());
             }
         } else {
-            throw new NoApplicableCodeException().at("method").withMessage(
-                    "The ProcessMethod should contain a href string or a RulesDefinition!");
+            throw new NoApplicableCodeException().at("method")
+                    .withMessage("The ProcessMethod should contain a href string or a RulesDefinition!");
         }
         return xbMethod;
     }
@@ -799,8 +787,7 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
      * @return XML Identification array
      */
     protected Identification[] createIdentification(final List<SmlIdentifier> identifications) {
-        final Identification xbIdentification =
-                Identification.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+        final Identification xbIdentification = Identification.Factory.newInstance(getOptions());
         final IdentifierList xbIdentifierList = xbIdentification.addNewIdentifierList();
         for (final SmlIdentifier sosSMLIdentifier : identifications) {
             final Identifier xbIdentifier = xbIdentifierList.addNewIdentifier();
@@ -822,8 +809,7 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
      * @return XML Classification array
      */
     private Classification[] createClassification(final List<SmlClassifier> classifications) {
-        final Classification xbClassification =
-                Classification.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+        final Classification xbClassification = Classification.Factory.newInstance(getOptions());
         final ClassifierList xbClassifierList = xbClassification.addNewClassifierList();
         for (final SmlClassifier sosSMLClassifier : classifications) {
             final Classifier xbClassifier = xbClassifierList.addNewClassifier();
@@ -857,16 +843,15 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
         final List<Characteristics> characteristicsList =
                 Lists.newArrayListWithExpectedSize(smlCharacteristics.size());
         for (final SmlCharacteristics sosSMLCharacteristics : smlCharacteristics) {
-        	final Characteristics xbCharacteristics =
-                    Characteristics.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
-        	 if (sosSMLCharacteristics.isSetName()) {
-             	xbCharacteristics.setName(sosSMLCharacteristics.getName());
+            final Characteristics xbCharacteristics = Characteristics.Factory.newInstance(getOptions());
+            if (sosSMLCharacteristics.isSetName()) {
+                xbCharacteristics.setName(sosSMLCharacteristics.getName());
             }
             if (sosSMLCharacteristics.isSetAbstractDataRecord()) {
                 if (sosSMLCharacteristics.getDataRecord() instanceof SweSimpleDataRecord) {
                     final SimpleDataRecordType xbSimpleDataRecord =
-                            (SimpleDataRecordType) xbCharacteristics.addNewAbstractDataRecord().substitute(
-                                    SweConstants.QN_SIMPLEDATARECORD_SWE_101, SimpleDataRecordType.type);
+                            (SimpleDataRecordType) xbCharacteristics.addNewAbstractDataRecord()
+                                    .substitute(SweConstants.QN_SIMPLEDATARECORD_SWE_101, SimpleDataRecordType.type);
                     if (sosSMLCharacteristics.isSetTypeDefinition()) {
                         xbSimpleDataRecord.setDefinition(sosSMLCharacteristics.getTypeDefinition());
                     }
@@ -878,24 +863,22 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
                         }
                     }
                 } else if (sosSMLCharacteristics.getDataRecord() instanceof SweDataRecord) {
-                    throw new NoApplicableCodeException()
-                            .withMessage(
-                                    "The SWE characteristics type '%s' is not supported by this SOS for SensorML characteristics!",
-                                    SweAggregateType.DataRecord);
+                    throw new NoApplicableCodeException().withMessage(
+                            "The SWE characteristics type '%s' is not supported by this SOS for SensorML characteristics!",
+                            SweAggregateType.DataRecord);
                 } else {
-                    throw new NoApplicableCodeException()
-                            .withMessage(
-                                    "The SWE characteristics type '%s' is not supported by this SOS for SensorML characteristics!",
-                                    sosSMLCharacteristics.getDataRecord().getClass().getName());
+                    throw new NoApplicableCodeException().withMessage(
+                            "The SWE characteristics type '%s' is not supported by this SOS for SensorML characteristics!",
+                            sosSMLCharacteristics.getDataRecord().getClass().getName());
                 }
             } else if (sosSMLCharacteristics.isSetHref()) {
-            	if (sosSMLCharacteristics.isSetName()) {
-            		xbCharacteristics.setName(sosSMLCharacteristics.getName());
+                if (sosSMLCharacteristics.isSetName()) {
+                    xbCharacteristics.setName(sosSMLCharacteristics.getName());
                 }
-            	xbCharacteristics.setHref(sosSMLCharacteristics.getHref());
-            	if (sosSMLCharacteristics.isSetTitle()) {
-            		xbCharacteristics.setTitle(sosSMLCharacteristics.getTitle());
-            	}
+                xbCharacteristics.setHref(sosSMLCharacteristics.getHref());
+                if (sosSMLCharacteristics.isSetTitle()) {
+                    xbCharacteristics.setTitle(sosSMLCharacteristics.getTitle());
+                }
             }
             characteristicsList.add(xbCharacteristics);
         }
@@ -986,7 +969,7 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
      *             if an error occurs
      */
     private Position createPosition(final SmlPosition position) throws OwsExceptionReport {
-        final Position xbPosition = Position.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+        final Position xbPosition = Position.Factory.newInstance(getOptions());
         if (position.isSetName()) {
             xbPosition.setName(position.getName().getValue());
         } else {
@@ -1016,8 +999,7 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
      *             if an error occurs
      */
     private SmlLocation2 createLocation(final SmlLocation location) throws OwsExceptionReport {
-        final SmlLocation2 xbLocation =
-                SmlLocation2.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+        final SmlLocation2 xbLocation = SmlLocation2.Factory.newInstance(getOptions());
         if (location.isSetPoint()) {
             final XmlObject xbPoint = CodingHelper.encodeObjectToXml(GmlConstants.NS_GML, location.getPoint());
             if (xbPoint instanceof PointType) {
@@ -1038,7 +1020,7 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
      *             if an error occurs
      */
     private Inputs createInputs(final List<SmlIo<?>> inputs) throws OwsExceptionReport {
-        final Inputs xbInputs = Inputs.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+        final Inputs xbInputs = Inputs.Factory.newInstance(getOptions());
         final InputList xbInputList = xbInputs.addNewInputList();
         int counter = 1;
         for (final SmlIo<?> sosSMLIo : inputs) {
@@ -1060,7 +1042,7 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
      * @throws OwsExceptionReport
      */
     private Outputs createOutputs(final List<SmlIo<?>> sosOutputs) throws OwsExceptionReport {
-        final Outputs outputs = Outputs.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+        final Outputs outputs = Outputs.Factory.newInstance(getOptions());
         final OutputList outputList = outputs.addNewOutputList();
         final Set<String> definitions = Sets.newHashSet();
         int counter = 1;
@@ -1087,7 +1069,7 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
      * @throws OwsExceptionReport
      */
     private Components createComponents(final List<SmlComponent> sosComponents) throws OwsExceptionReport {
-        final Components components = Components.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+        final Components components = Components.Factory.newInstance(getOptions());
         final ComponentList componentList = components.addNewComponentList();
         for (final SmlComponent sosSMLComponent : sosComponents) {
             final Component component = componentList.addNewComponent();
@@ -1109,8 +1091,8 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
                                 XmlObject.Factory.parse(sosSMLComponent.getProcess().getSensorDescriptionXmlString());
 
                     } catch (final XmlException xmle) {
-                        throw new NoApplicableCodeException().causedBy(xmle).withMessage(
-                                "Error while encoding SensorML child procedure description "
+                        throw new NoApplicableCodeException().causedBy(xmle)
+                                .withMessage("Error while encoding SensorML child procedure description "
                                         + "from stored SensorML encoded sensor description with XMLBeans");
                     }
                 } else {
@@ -1152,11 +1134,10 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
      * @throws OwsExceptionReport
      *             if an error occurs
      */
-    private void addSweSimpleTypeToField(final AnyScalarPropertyType xbField, final SweAbstractDataComponent sosSweData)
-            throws OwsExceptionReport {
-        final Encoder<?, SweAbstractDataComponent> encoder =
-                CodingRepository.getInstance().getEncoder(
-                        new XmlEncoderKey(SweConstants.NS_SWE_101, SweDataArray.class));
+    private void addSweSimpleTypeToField(final AnyScalarPropertyType xbField,
+            final SweAbstractDataComponent sosSweData) throws OwsExceptionReport {
+        final Encoder<?, SweAbstractDataComponent> encoder = CodingRepository.getInstance()
+                .getEncoder(new XmlEncoderKey(SweConstants.NS_SWE_101, SweDataArray.class));
         if (encoder != null) {
             final XmlObject encoded = (XmlObject) encoder.encode(sosSweData);
             if (sosSweData instanceof SweAbstractSimpleType) {
@@ -1182,8 +1163,8 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
                     break;
                 default:
                     throw new NoApplicableCodeException().withMessage(
-                            "The SWE simpleType '%s' is not supported by this SOS SensorML encoder!", sosSweSimpleType
-                                    .getDataComponentType().name());
+                            "The SWE simpleType '%s' is not supported by this SOS SensorML encoder!",
+                            sosSweSimpleType.getDataComponentType().name());
                 }
             } else {
                 throw new NoApplicableCodeException().withMessage(
@@ -1243,14 +1224,18 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
             ioComponentPropertyType.addNewTimeRange().set(encodeObjectToXml);
             break;
         case DataArray:
-        	if (encodeObjectToXml instanceof DataArrayDocument) {
-        		ioComponentPropertyType.addNewAbstractDataArray1().set(((DataArrayDocument)encodeObjectToXml).getDataArray1()).substitute(SweConstants.QN_DATA_ARRAY_SWE_101, DataArrayType.type);
-        	} else {
-        		ioComponentPropertyType.addNewAbstractDataArray1().set(encodeObjectToXml).substitute(SweConstants.QN_DATA_ARRAY_SWE_101, DataArrayType.type);
-        	}
+            if (encodeObjectToXml instanceof DataArrayDocument) {
+                ioComponentPropertyType.addNewAbstractDataArray1()
+                        .set(((DataArrayDocument) encodeObjectToXml).getDataArray1())
+                        .substitute(SweConstants.QN_DATA_ARRAY_SWE_101, DataArrayType.type);
+            } else {
+                ioComponentPropertyType.addNewAbstractDataArray1().set(encodeObjectToXml)
+                        .substitute(SweConstants.QN_DATA_ARRAY_SWE_101, DataArrayType.type);
+            }
             break;
         case DataRecord:
-            ioComponentPropertyType.addNewAbstractDataRecord().set(encodeObjectToXml).substitute(SweConstants.QN_DATA_RECORD_SWE_101, DataRecordType.type);
+            ioComponentPropertyType.addNewAbstractDataRecord().set(encodeObjectToXml)
+                    .substitute(SweConstants.QN_DATA_RECORD_SWE_101, DataRecordType.type);
             break;
         default:
 
@@ -1273,5 +1258,4 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
         return SensorMLConstants.ABSTRACT_PROCESS_QNAME;
     }
 
-   
 }

--- a/coding/sensorML-v20/src/main/java/org/n52/sos/decode/SensorMLDecoderV20.java
+++ b/coding/sensorML-v20/src/main/java/org/n52/sos/decode/SensorMLDecoderV20.java
@@ -516,17 +516,24 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
                 CharacteristicListType clt = clpt.getCharacteristicList();
                 if (CollectionHelper.isNotNullOrEmpty(clt.getCharacteristicArray())) {
                     for (Characteristic c : clt.getCharacteristicArray()) {
-                        final Object o = CodingHelper.decodeXmlElement(c.getAbstractDataComponent());
-                        if (o instanceof SweAbstractDataComponent) {
-                            final SmlCharacteristic characteristic =
-                                    new SmlCharacteristic(c.getName(), (SweAbstractDataComponent) o);
-                            sosCharacteristics.addCharacteristic(characteristic);
-                        } else {
-                            throw new InvalidParameterValueException()
-                                    .at(XmlHelper.getLocalName(clpt))
-                                    .withMessage(
-                                            "Error while parsing the characteristics of the SensorML (the characteristics' data record is not of type DataRecordPropertyType)!");
-                        }
+                    	final SmlCharacteristic characteristic = new SmlCharacteristic(c.getName());
+                    	if (c.isSetAbstractDataComponent()) {
+                    		final Object o = CodingHelper.decodeXmlElement(c.getAbstractDataComponent());
+                            if (o instanceof SweAbstractDataComponent) {
+                                characteristic.setAbstractDataComponent((SweAbstractDataComponent) o);
+                            } else {
+                                throw new InvalidParameterValueException()
+                                        .at(XmlHelper.getLocalName(clpt))
+                                        .withMessage(
+                                                "Error while parsing the characteristics of the SensorML (the characteristics' data record is not of type DataRecordPropertyType)!");
+                            }
+                    	} else if (c.isSetHref()) {
+                    		characteristic.setHref(c.getHref());
+                    		if (c.isSetTitle()) {
+                    			characteristic.setTitle(c.getTitle());
+                    		}
+                    	}
+                    	sosCharacteristics.addCharacteristic(characteristic);
                     }
                 }
             }
@@ -556,11 +563,11 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
                 CapabilityListType cl = cs.getCapabilityList();
                 if (CollectionHelper.isNotNullOrEmpty(cl.getCapabilityArray())) {
                     for (Capability c : cl.getCapabilityArray()) {
+                    	final SmlCapability capability = new SmlCapability(c.getName());
                         if (c.isSetAbstractDataComponent()) {
                             final Object o = CodingHelper.decodeXmlElement(c.getAbstractDataComponent());
                             if (o instanceof SweAbstractDataComponent) {
-                                final SmlCapability capability =
-                                        new SmlCapability(c.getName(), (SweAbstractDataComponent) o);
+                                capability.setAbstractDataComponent((SweAbstractDataComponent) o);
                                 // check if this capabilities is insertion
                                 // metadata
                                 if (SensorMLConstants.ELEMENT_NAME_OFFERINGS.equals(cs.getName())) {
@@ -588,6 +595,11 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
                                                 + "the SensorML (the capabilities data record "
                                                 + "is not of type DataRecordPropertyType)!");
                             }
+                        } else if (c.isSetHref()) {
+                        	capability.setHref(c.getHref());
+                        	if (c.isSetTitle()) {
+                        		capability.setTitle(c.getTitle());
+                        	}
                         }
                     }
                 }

--- a/coding/sensorML-v20/src/main/java/org/n52/sos/decode/SensorMLDecoderV20.java
+++ b/coding/sensorML-v20/src/main/java/org/n52/sos/decode/SensorMLDecoderV20.java
@@ -153,26 +153,26 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
             SensorML20Constants.NS_SML_20, DescribedObjectDocument.class, SimpleProcessDocument.class,
             PhysicalComponentDocument.class, PhysicalSystemDocument.class, AbstractProcessDocument.class);
 
-    private static final Set<String> SUPPORTED_PROCEDURE_DESCRIPTION_FORMATS = Collections
-            .singleton(SensorML20Constants.SENSORML_20_OUTPUT_FORMAT_URL);
+    private static final Set<String> SUPPORTED_PROCEDURE_DESCRIPTION_FORMATS =
+            Collections.singleton(SensorML20Constants.SENSORML_20_OUTPUT_FORMAT_URL);
 
-    private static final Set<String> REMOVABLE_CAPABILITIES_NAMES = Sets
-            .newHashSet(SensorMLConstants.ELEMENT_NAME_OFFERINGS);
+    private static final Set<String> REMOVABLE_CAPABILITIES_NAMES =
+            Sets.newHashSet(SensorMLConstants.ELEMENT_NAME_OFFERINGS);
 
-    private static final Set<String> REMOVABLE_COMPONENTS_ROLES = Collections
-            .singleton(SensorMLConstants.ELEMENT_NAME_CHILD_PROCEDURES);
-    
+    private static final Set<String> REMOVABLE_COMPONENTS_ROLES =
+            Collections.singleton(SensorMLConstants.ELEMENT_NAME_CHILD_PROCEDURES);
+
     private static final Map<String, ImmutableMap<String, Set<String>>> SUPPORTED_TRANSACTIONAL_PROCEDURE_DESCRIPTION_FORMATS =
-            ImmutableMap.of(
-                    SosConstants.SOS,
-                    ImmutableMap
-                            .<String, Set<String>> builder()
-                            .put(Sos2Constants.SERVICEVERSION,
-                                    ImmutableSet.of(SensorML20Constants.SENSORML_20_OUTPUT_FORMAT_URL)).build());
+            ImmutableMap
+                    .of(SosConstants.SOS,
+                            ImmutableMap.<String, Set<String>> builder()
+                                    .put(Sos2Constants.SERVICEVERSION,
+                                            ImmutableSet.of(SensorML20Constants.SENSORML_20_OUTPUT_FORMAT_URL))
+                                    .build());
 
     public SensorMLDecoderV20() {
-        LOGGER.debug("Decoder for the following keys initialized successfully: {}!", Joiner.on(", ")
-                .join(DECODER_KEYS));
+        LOGGER.debug("Decoder for the following keys initialized successfully: {}!",
+                Joiner.on(", ").join(DECODER_KEYS));
     }
 
     @Override
@@ -190,7 +190,7 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
         return Collections.singletonMap(SupportedTypeKey.ProcedureDescriptionFormat,
                 SUPPORTED_PROCEDURE_DESCRIPTION_FORMATS);
     }
-    
+
     @Override
     public Set<String> getSupportedProcedureDescriptionFormats(final String service, final String version) {
         if (SUPPORTED_TRANSACTIONAL_PROCEDURE_DESCRIPTION_FORMATS.containsKey(service)
@@ -206,7 +206,7 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
         XmlHelper.validateDocument(element);
         return parse(element);
     }
-    
+
     private AbstractSensorML parse(XmlObject element) throws OwsExceptionReport, UnsupportedDecoderInputException {
         AbstractSensorML sml = null;
         if (element instanceof PhysicalSystemDocument) {
@@ -243,41 +243,49 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
     }
 
     private void setXmlDescription(XmlObject xml, AbstractSensorML sml) {
-       XmlObject xmlToString = null;
-        if (xml.schemaType()!= null && xml.schemaType().isDocumentType()) {
+        XmlObject xmlToString = null;
+        if (xml.schemaType() != null && xml.schemaType().isDocumentType()) {
             xmlToString = xml;
         } else {
-             // check and create documents if necessary
-             if (xml instanceof PhysicalSystemPropertyType) {
-                 PhysicalSystemDocument psd = PhysicalSystemDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
-                 psd.setPhysicalSystem(((PhysicalSystemPropertyType) xml).getPhysicalSystem());
-                 xmlToString = psd;
+            // check and create documents if necessary
+            if (xml instanceof PhysicalSystemPropertyType) {
+                PhysicalSystemDocument psd =
+                        PhysicalSystemDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+                psd.setPhysicalSystem(((PhysicalSystemPropertyType) xml).getPhysicalSystem());
+                xmlToString = psd;
             } else if (xml instanceof PhysicalSystemType) {
-                PhysicalSystemDocument psd = PhysicalSystemDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+                PhysicalSystemDocument psd =
+                        PhysicalSystemDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
                 psd.setPhysicalSystem((PhysicalSystemType) xml);
                 xmlToString = psd;
             } else if (xml instanceof PhysicalComponentPropertyType) {
-                PhysicalComponentDocument pcd = PhysicalComponentDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+                PhysicalComponentDocument pcd =
+                        PhysicalComponentDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
                 pcd.setPhysicalComponent(((PhysicalComponentPropertyType) xml).getPhysicalComponent());
                 xmlToString = pcd;
             } else if (xml instanceof PhysicalComponentType) {
-                PhysicalComponentDocument pcd = PhysicalComponentDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+                PhysicalComponentDocument pcd =
+                        PhysicalComponentDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
                 pcd.setPhysicalComponent((PhysicalComponentType) xml);
                 xmlToString = pcd;
             } else if (xml instanceof SimpleProcessPropertyType) {
-                SimpleProcessDocument spd = SimpleProcessDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+                SimpleProcessDocument spd =
+                        SimpleProcessDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
                 spd.setSimpleProcess(((SimpleProcessPropertyType) xml).getSimpleProcess());
                 xmlToString = spd;
             } else if (xml instanceof SimpleProcessPropertyType) {
-                SimpleProcessDocument spd = SimpleProcessDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+                SimpleProcessDocument spd =
+                        SimpleProcessDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
                 spd.setSimpleProcess((SimpleProcessType) xml);
                 xmlToString = spd;
             } else if (xml instanceof AggregateProcessPropertyType) {
-                AggregateProcessDocument apd = AggregateProcessDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+                AggregateProcessDocument apd =
+                        AggregateProcessDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
                 apd.setAggregateProcess(((AggregateProcessPropertyType) xml).getAggregateProcess());
                 xmlToString = apd;
             } else if (xml instanceof AggregateProcessType) {
-                AggregateProcessDocument apd = AggregateProcessDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
+                AggregateProcessDocument apd =
+                        AggregateProcessDocument.Factory.newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
                 apd.setAggregateProcess((AggregateProcessType) xml);
                 xmlToString = apd;
             }
@@ -456,7 +464,8 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
         return Lists.newArrayList(keywords);
     }
 
-    private void parseIdentifications(DescribedObject describedObject, IdentifierListPropertyType[] identificationArray) {
+    private void parseIdentifications(DescribedObject describedObject,
+            IdentifierListPropertyType[] identificationArray) {
         for (final IdentifierListPropertyType ilpt : identificationArray) {
             if (ilpt.isSetIdentifierList()
                     && CollectionHelper.isNotNullOrEmpty(ilpt.getIdentifierList().getIdentifier2Array())) {
@@ -516,24 +525,23 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
                 CharacteristicListType clt = clpt.getCharacteristicList();
                 if (CollectionHelper.isNotNullOrEmpty(clt.getCharacteristicArray())) {
                     for (Characteristic c : clt.getCharacteristicArray()) {
-                    	final SmlCharacteristic characteristic = new SmlCharacteristic(c.getName());
-                    	if (c.isSetAbstractDataComponent()) {
-                    		final Object o = CodingHelper.decodeXmlElement(c.getAbstractDataComponent());
+                        final SmlCharacteristic characteristic = new SmlCharacteristic(c.getName());
+                        if (c.isSetAbstractDataComponent()) {
+                            final Object o = CodingHelper.decodeXmlElement(c.getAbstractDataComponent());
                             if (o instanceof SweAbstractDataComponent) {
                                 characteristic.setAbstractDataComponent((SweAbstractDataComponent) o);
                             } else {
-                                throw new InvalidParameterValueException()
-                                        .at(XmlHelper.getLocalName(clpt))
+                                throw new InvalidParameterValueException().at(XmlHelper.getLocalName(clpt))
                                         .withMessage(
                                                 "Error while parsing the characteristics of the SensorML (the characteristics' data record is not of type DataRecordPropertyType)!");
                             }
-                    	} else if (c.isSetHref()) {
-                    		characteristic.setHref(c.getHref());
-                    		if (c.isSetTitle()) {
-                    			characteristic.setTitle(c.getTitle());
-                    		}
-                    	}
-                    	sosCharacteristics.addCharacteristic(characteristic);
+                        } else if (c.isSetHref()) {
+                            characteristic.setHref(c.getHref());
+                            if (c.isSetTitle()) {
+                                characteristic.setTitle(c.getTitle());
+                            }
+                        }
+                        sosCharacteristics.addCharacteristic(characteristic);
                     }
                 }
             }
@@ -563,7 +571,7 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
                 CapabilityListType cl = cs.getCapabilityList();
                 if (CollectionHelper.isNotNullOrEmpty(cl.getCapabilityArray())) {
                     for (Capability c : cl.getCapabilityArray()) {
-                    	final SmlCapability capability = new SmlCapability(c.getName());
+                        final SmlCapability capability = new SmlCapability(c.getName());
                         if (c.isSetAbstractDataComponent()) {
                             final Object o = CodingHelper.decodeXmlElement(c.getAbstractDataComponent());
                             if (o instanceof SweAbstractDataComponent) {
@@ -572,8 +580,8 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
                                 // metadata
                                 if (SensorMLConstants.ELEMENT_NAME_OFFERINGS.equals(cs.getName())) {
                                     if (o instanceof DataRecord) {
-                                        abstractProcess.addOfferings(SosOffering.fromSet(((DataRecord) o)
-                                                .getSweAbstractSimpleTypeFromFields(SweText.class)));
+                                        abstractProcess.addOfferings(SosOffering.fromSet(
+                                                ((DataRecord) o).getSweAbstractSimpleTypeFromFields(SweText.class)));
                                     } else if (o instanceof SweAbstractSimpleType<?>) {
                                         abstractProcess.addOffering(SosOffering.from((SweAbstractSimpleType<?>) o));
                                     }
@@ -590,16 +598,16 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
                                 }
                                 capabilities.addCapability(capability);
                             } else {
-                                throw new InvalidParameterValueException().at(XmlHelper.getLocalName(cs)).withMessage(
-                                        "Error while parsing the capabilities of "
+                                throw new InvalidParameterValueException().at(XmlHelper.getLocalName(cs))
+                                        .withMessage("Error while parsing the capabilities of "
                                                 + "the SensorML (the capabilities data record "
                                                 + "is not of type DataRecordPropertyType)!");
                             }
                         } else if (c.isSetHref()) {
-                        	capability.setHref(c.getHref());
-                        	if (c.isSetTitle()) {
-                        		capability.setTitle(c.getTitle());
-                        	}
+                            capability.setHref(c.getHref());
+                            if (c.isSetTitle()) {
+                                capability.setTitle(c.getTitle());
+                            }
                         }
                     }
                 }
@@ -611,14 +619,15 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
     private List<SmlContact> parseContact(final ContactListPropertyType[] clpts) throws OwsExceptionReport {
         List<SmlContact> smlContacts = Lists.newArrayList();
         for (ContactListPropertyType clpt : clpts) {
-            if (clpt.isSetContactList() && CollectionHelper.isNotNullOrEmpty(clpt.getContactList().getContactArray())) {
+            if (clpt.isSetContactList()
+                    && CollectionHelper.isNotNullOrEmpty(clpt.getContactList().getContactArray())) {
                 for (CIResponsiblePartyPropertyType c : clpt.getContactList().getContactArray()) {
                     final Object o = CodingHelper.decodeXmlElement(c);
                     if (o instanceof SmlContact) {
                         smlContacts.add((SmlContact) o);
                     } else {
-                        throw new InvalidParameterValueException().at(XmlHelper.getLocalName(c)).withMessage(
-                                "Error while parsing the contacts of " + "the SensorML!");
+                        throw new InvalidParameterValueException().at(XmlHelper.getLocalName(c))
+                                .withMessage("Error while parsing the contacts of " + "the SensorML!");
                     }
                 }
             }
@@ -758,8 +767,8 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
                 && OGCConstants.UNIQUE_ID.equals(ap.getIdentifierCodeWithAuthority().getCodeSpace())) {
             return true;
         } else {
-            throw new InvalidParameterValueException("gml:identifier[@codesSpace]", ap
-                    .getIdentifierCodeWithAuthority().getCodeSpace());
+            throw new InvalidParameterValueException("gml:identifier[@codesSpace]",
+                    ap.getIdentifierCodeWithAuthority().getCodeSpace());
         }
     }
 
@@ -796,14 +805,14 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
             if (components.getComponentList() == null) {
                 removeComponents = true;
             } else if (components.getComponentList().getComponentArray() == null
-                    || ((components.getComponentList().getComponentArray() != null && components.getComponentList()
-                            .getComponentArray().length == 0))) {
+                    || ((components.getComponentList().getComponentArray() != null
+                            && components.getComponentList().getComponentArray().length == 0))) {
                 removeComponents = true;
             }
         }
         return removeComponents;
     }
-    
+
     @SuppressWarnings({ "rawtypes" })
     private SmlIo<?> parseInput(Input xbInput) throws OwsExceptionReport {
         final SmlIo<?> sosIo = new SmlIo();
@@ -811,7 +820,7 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
         sosIo.setIoValue(parseDataComponentOrObservablePropertyType(xbInput));
         return sosIo;
     }
-    
+
     @SuppressWarnings({ "rawtypes" })
     private SmlIo<?> parseOutput(Output xbOutput) throws OwsExceptionReport {
         final SmlIo<?> sosIo = new SmlIo();
@@ -831,51 +840,54 @@ public class SensorMLDecoderV20 extends AbstractSensorMLDecoder {
      * @throws OwsExceptionReport
      *             * if an error occurs
      */
-    private SweAbstractDataComponent parseDataComponentOrObservablePropertyType(final DataComponentOrObservablePropertyType adcpt)
-            throws OwsExceptionReport {
+    private SweAbstractDataComponent parseDataComponentOrObservablePropertyType(
+            final DataComponentOrObservablePropertyType adcpt) throws OwsExceptionReport {
         XmlObject toDecode = null;
         if (adcpt.isSetObservableProperty()) {
-           return parseObservableProperty(adcpt.getObservableProperty());
+            return parseObservableProperty(adcpt.getObservableProperty());
         } else if (adcpt.isSetAbstractDataComponent()) {
             final Object decodedObject = CodingHelper.decodeXmlElement(adcpt.getAbstractDataComponent());
             if (decodedObject instanceof SweAbstractDataComponent) {
-               return (SweAbstractDataComponent) decodedObject;
+                return (SweAbstractDataComponent) decodedObject;
             } else {
                 throw new InvalidParameterValueException().at(XmlHelper.getLocalName(adcpt)).withMessage(
                         "The 'DataComponentOrObservablePropertyType' with type '%s' as value for '%s' is not supported.",
                         XmlHelper.getLocalName(toDecode), XmlHelper.getLocalName(adcpt));
             }
         } else if (adcpt.isSetDataInterface()) {
-        	return parseDataInterfaceType(adcpt.getDataInterface());
+            return parseDataInterfaceType(adcpt.getDataInterface());
         } else {
-            throw new InvalidParameterValueException().at(XmlHelper.getLocalName(adcpt)).withMessage(
-                    "An 'DataComponentOrObservablePropertyType' is not supported");
+            throw new InvalidParameterValueException().at(XmlHelper.getLocalName(adcpt))
+                    .withMessage("An 'DataComponentOrObservablePropertyType' is not supported");
         }
     }
-    
+
     protected SmlDataInterface parseDataInterfaceType(DataInterfaceType xbDataInterface) throws OwsExceptionReport {
-		SmlDataInterface dataInterface = new SmlDataInterface();
-		// TODO implement- no funding at the moment available
-		// When starting implementation: Do not forget to activate the already available unit tests
-//		dataInterface.setData(parseDataStreamPropertyType(xbDataInterface.getData()));
-//		if (xbDataInterface.isSetInterfaceParameters()) {
-//			final Object decodedObject = CodingHelper.decodeXmlElement(xbDataInterface.getInterfaceParameters());
-//			if (decodedObject instanceof SweDataRecord) {
-//				dataInterface.setInputParameters((SweDataRecord)decodedObject);
-//			}
-//			// TODO throw exception if not instance of SweDataRecord
-//		}
-		return dataInterface;
-	}
+        SmlDataInterface dataInterface = new SmlDataInterface();
+        // TODO implement- no funding at the moment available
+        // When starting implementation: Do not forget to activate the already
+        // available unit tests
+        // dataInterface.setData(parseDataStreamPropertyType(xbDataInterface.getData()));
+        // if (xbDataInterface.isSetInterfaceParameters()) {
+        // final Object decodedObject =
+        // CodingHelper.decodeXmlElement(xbDataInterface.getInterfaceParameters());
+        // if (decodedObject instanceof SweDataRecord) {
+        // dataInterface.setInputParameters((SweDataRecord)decodedObject);
+        // }
+        // // TODO throw exception if not instance of SweDataRecord
+        // }
+        return dataInterface;
+    }
 
-	protected SmlDataStreamPropertyType parseDataStreamPropertyType(
-			DataStreamPropertyType data) {
-		return new SmlDataStreamPropertyType();
-	}
+    protected SmlDataStreamPropertyType parseDataStreamPropertyType(DataStreamPropertyType data) {
+        return new SmlDataStreamPropertyType();
+    }
 
-	/**
-     * Parse {@link ObservablePropertyType} 
-     * @param opt Object to parse
+    /**
+     * Parse {@link ObservablePropertyType}
+     * 
+     * @param opt
+     *            Object to parse
      * @return Parsed {@link SweObservableProperty}
      */
     private SweObservableProperty parseObservableProperty(ObservablePropertyType opt) {

--- a/coding/sensorML-v20/src/main/java/org/n52/sos/encode/SensorMLEncoderv20.java
+++ b/coding/sensorML-v20/src/main/java/org/n52/sos/encode/SensorMLEncoderv20.java
@@ -1074,21 +1074,27 @@ public class SensorMLEncoderv20 extends AbstractSensorMLEncoder {
         final List<Characteristics> characteristicsList =
                 Lists.newArrayListWithExpectedSize(smlCharacteristics.size());
         for (final SmlCharacteristics sosSMLCharacteristics : smlCharacteristics) {
-            if (sosSMLCharacteristics.isSetAbstractDataComponents()) {
-                Characteristics xbCharacteristics = Characteristics.Factory.newInstance(getOptions());
-                CharacteristicListType characteristicList = xbCharacteristics.addNewCharacteristicList();
-                if (sosSMLCharacteristics.isSetCharacteristics()) {
-                    for (SmlCharacteristic characteristic : sosSMLCharacteristics.getCharacteristic()) {
-                        if (characteristic.isSetAbstractDataComponent()) {
-                            XmlObject encodeObjectToXml = CodingHelper.encodeObjectToXml(SweConstants.NS_SWE_20, characteristic.getAbstractDataComponent());
-                            Characteristic c = characteristicList.addNewCharacteristic();
-                            c.setName(NcNameResolver.fixNcName(characteristic.getName()));
-                            XmlObject substituteElement =
-                                    XmlHelper.substituteElement(c.addNewAbstractDataComponent(), encodeObjectToXml);
-                            substituteElement.set(encodeObjectToXml);
-                        }
+        	Characteristics xbCharacteristics = Characteristics.Factory.newInstance(getOptions());
+            CharacteristicListType characteristicList = xbCharacteristics.addNewCharacteristicList();
+            if (sosSMLCharacteristics.isSetCharacteristics()) {
+            	for (SmlCharacteristic characteristic : sosSMLCharacteristics.getCharacteristic()) {
+            		Characteristic c = characteristicList.addNewCharacteristic();
+            		c.setName(NcNameResolver.fixNcName(characteristic.getName()));
+            		if (characteristic.isSetAbstractDataComponent()) {
+                        XmlObject encodeObjectToXml = CodingHelper.encodeObjectToXml(SweConstants.NS_SWE_20, characteristic.getAbstractDataComponent());
+                        XmlObject substituteElement =
+                                XmlHelper.substituteElement(c.addNewAbstractDataComponent(), encodeObjectToXml);
+                        substituteElement.set(encodeObjectToXml);
+                    } else if (characteristic.isSetHref()) {
+                    	c.setHref(characteristic.getHref());
+                    	if (characteristic.isSetTitle()) {
+                    		c.setTitle(characteristic.getTitle());
+                    	}
                     }
-                } else if (sosSMLCharacteristics.isSetAbstractDataComponents()) {
+                }
+            }
+            if (sosSMLCharacteristics.isSetAbstractDataComponents()) {
+                if (sosSMLCharacteristics.isSetAbstractDataComponents()) {
                     for (SweAbstractDataComponent component : sosSMLCharacteristics.getAbstractDataComponents()) {
                         XmlObject encodeObjectToXml = CodingHelper.encodeObjectToXml(SweConstants.NS_SWE_20, component);
                         Characteristic c = characteristicList.addNewCharacteristic();
@@ -1098,8 +1104,9 @@ public class SensorMLEncoderv20 extends AbstractSensorMLEncoder {
                         substituteElement.set(encodeObjectToXml);
                     }
                 }
-                characteristicsList.add(xbCharacteristics);
-            }
+                
+            } 
+            characteristicsList.add(xbCharacteristics);
         }
         return characteristicsList.toArray(new Characteristics[characteristicsList.size()]);
     }

--- a/coding/sos-v20/src/main/java/org/n52/sos/encode/SamplingEncoderv20.java
+++ b/coding/sos-v20/src/main/java/org/n52/sos/encode/SamplingEncoderv20.java
@@ -81,23 +81,23 @@ public class SamplingEncoderv20 extends AbstractXmlEncoder<AbstractFeature> {
     private static final Logger LOGGER = LoggerFactory.getLogger(SamplingEncoderv20.class);
 
     @SuppressWarnings("unchecked")
-    private static final Set<EncoderKey> ENCODER_KEYS = CollectionHelper.union(
-            CodingHelper.encoderKeysForElements(SfConstants.NS_SAMS, AbstractFeature.class),
-            CodingHelper.encoderKeysForElements(SfConstants.NS_SF, AbstractFeature.class));
+    private static final Set<EncoderKey> ENCODER_KEYS =
+            CollectionHelper.union(CodingHelper.encoderKeysForElements(SfConstants.NS_SAMS, AbstractFeature.class),
+                    CodingHelper.encoderKeysForElements(SfConstants.NS_SF, AbstractFeature.class));
 
-    private static final Set<String> CONFORMANCE_CLASSES = Sets.newHashSet(ConformanceClasses.OM_V2_SPATIAL_SAMPLING,
-            ConformanceClasses.OM_V2_SAMPLING_POINT, ConformanceClasses.OM_V2_SAMPLING_CURVE,
-            ConformanceClasses.OM_V2_SAMPLING_SURFACE);
+    private static final Set<String> CONFORMANCE_CLASSES =
+            Sets.newHashSet(ConformanceClasses.OM_V2_SPATIAL_SAMPLING, ConformanceClasses.OM_V2_SAMPLING_POINT,
+                    ConformanceClasses.OM_V2_SAMPLING_CURVE, ConformanceClasses.OM_V2_SAMPLING_SURFACE);
 
     private static final Map<SupportedTypeKey, Set<String>> SUPPORTED_TYPES = Collections.singletonMap(
-            SupportedTypeKey.FeatureType, (Set<String>) Sets.newHashSet(OGCConstants.UNKNOWN,
-                    SfConstants.SAMPLING_FEAT_TYPE_SF_SAMPLING_POINT,
+            SupportedTypeKey.FeatureType,
+            (Set<String>) Sets.newHashSet(OGCConstants.UNKNOWN, SfConstants.SAMPLING_FEAT_TYPE_SF_SAMPLING_POINT,
                     SfConstants.SAMPLING_FEAT_TYPE_SF_SAMPLING_CURVE,
                     SfConstants.SAMPLING_FEAT_TYPE_SF_SAMPLING_SURFACE));
 
     public SamplingEncoderv20() {
-        LOGGER.debug("Encoder for the following keys initialized successfully: {}!", Joiner.on(", ")
-                .join(ENCODER_KEYS));
+        LOGGER.debug("Encoder for the following keys initialized successfully: {}!",
+                Joiner.on(", ").join(ENCODER_KEYS));
     }
 
     @Override
@@ -144,14 +144,12 @@ public class SamplingEncoderv20 extends AbstractXmlEncoder<AbstractFeature> {
             builder.append(JavaHelper.generateID(absFeature.getIdentifierCodeWithAuthority().getValue()));
             absFeature.setGmlId(builder.toString());
 
-            final SFSpatialSamplingFeatureDocument xbSampFeatDoc =
-                    SFSpatialSamplingFeatureDocument.Factory.newInstance(XmlOptionsHelper.getInstance()
-                            .getXmlOptions());
+            final SFSpatialSamplingFeatureDocument xbSampFeatDoc = SFSpatialSamplingFeatureDocument.Factory
+                    .newInstance(XmlOptionsHelper.getInstance().getXmlOptions());
             if (sampFeat.getXmlDescription() != null) {
                 try {
-                    final XmlObject feature =
-                            XmlObject.Factory.parse(sampFeat.getXmlDescription(), XmlOptionsHelper.getInstance()
-                                    .getXmlOptions());
+                    final XmlObject feature = XmlObject.Factory.parse(sampFeat.getXmlDescription(),
+                            XmlOptionsHelper.getInstance().getXmlOptions());
                     XmlHelper.updateGmlIDs(feature.getDomNode().getFirstChild(), absFeature.getGmlId(), null);
                     if (XmlHelper.getNamespace(feature).equals(SfConstants.NS_SAMS)
                             && feature instanceof SFSpatialSamplingFeatureType) {
@@ -162,24 +160,22 @@ public class SamplingEncoderv20 extends AbstractXmlEncoder<AbstractFeature> {
                     }
                     encodeShape(((SFSpatialSamplingFeatureDocument) feature).getSFSpatialSamplingFeature().getShape(),
                             sampFeat);
-                    addNameDescription(((SFSpatialSamplingFeatureDocument) feature).getSFSpatialSamplingFeature(), sampFeat);
+                    addNameDescription(((SFSpatialSamplingFeatureDocument) feature).getSFSpatialSamplingFeature(),
+                            sampFeat);
                     return feature;
                 } catch (final XmlException xmle) {
-                    throw new NoApplicableCodeException()
-                            .causedBy(xmle)
-                            .withMessage(
-                                    "Error while encoding GetFeatureOfInterest response, invalid samplingFeature description!");
+                    throw new NoApplicableCodeException().causedBy(xmle).withMessage(
+                            "Error while encoding GetFeatureOfInterest response, invalid samplingFeature description!");
                 }
             }
             final SFSpatialSamplingFeatureType xbSampFeature = xbSampFeatDoc.addNewSFSpatialSamplingFeature();
             // TODO: CHECK for all fields set gml:id
             xbSampFeature.setId(absFeature.getGmlId());
 
-            if (sampFeat.isSetIdentifier()
-                    && SosHelper.checkFeatureOfInterestIdentifierForSosV2(sampFeat.getIdentifierCodeWithAuthority().getValue(),
-                            Sos2Constants.SERVICEVERSION)) {
-                xbSampFeature.addNewIdentifier().set(
-                        CodingHelper.encodeObjectToXml(GmlConstants.NS_GML_32, sampFeat.getIdentifierCodeWithAuthority()));
+            if (sampFeat.isSetIdentifier() && SosHelper.checkFeatureOfInterestIdentifierForSosV2(
+                    sampFeat.getIdentifierCodeWithAuthority().getValue(), Sos2Constants.SERVICEVERSION)) {
+                xbSampFeature.addNewIdentifier().set(CodingHelper.encodeObjectToXml(GmlConstants.NS_GML_32,
+                        sampFeat.getIdentifierCodeWithAuthority()));
             }
 
             // set type
@@ -190,7 +186,7 @@ public class SamplingEncoderv20 extends AbstractXmlEncoder<AbstractFeature> {
                     addFeatureTypeForGeometry(xbSampFeature, sampFeat.getGeometry());
                 }
             }
-            
+
             addNameDescription(xbSampFeature, sampFeat);
 
             // set sampledFeatures
@@ -203,22 +199,28 @@ public class SamplingEncoderv20 extends AbstractXmlEncoder<AbstractFeature> {
                             CodingHelper.encodeObjectToXml(GmlConstants.NS_GML_32, sampledFeature, additionalValues);
                     xbSampFeature.addNewSampledFeature().set(encodeObjectToXml);
                 }
-//                // Old version before schema was fixed. Now sampledFeatures multiplicity is 1..* and not 1..1.
-//                if (sampFeat.getSampledFeatures().size() == 1) {
-//                    final XmlObject encodeObjectToXml =
-//                            CodingHelper.encodeObjectToXml(GmlConstants.NS_GML_32, sampFeat.getSampledFeatures()
-//                                    .get(0));
-//                    xbSampFeature.addNewSampledFeature().set(encodeObjectToXml);
-//                } else {
-//                    final FeatureCollection featureCollection = new FeatureCollection();
-//                    featureCollection.setGmlId("sampledFeatures_" + absFeature.getGmlId());
-//                    for (final AbstractFeature sampledFeature : sampFeat.getSampledFeatures()) {
-//                        featureCollection.addMember(sampledFeature);
-//                    }
-//                    final XmlObject encodeObjectToXml =
-//                            CodingHelper.encodeObjectToXml(GmlConstants.NS_GML_32, featureCollection);
-//                    xbSampFeature.addNewSampledFeature().set(encodeObjectToXml);
-//                }
+                // // Old version before schema was fixed. Now sampledFeatures
+                // multiplicity is 1..* and not 1..1.
+                // if (sampFeat.getSampledFeatures().size() == 1) {
+                // final XmlObject encodeObjectToXml =
+                // CodingHelper.encodeObjectToXml(GmlConstants.NS_GML_32,
+                // sampFeat.getSampledFeatures()
+                // .get(0));
+                // xbSampFeature.addNewSampledFeature().set(encodeObjectToXml);
+                // } else {
+                // final FeatureCollection featureCollection = new
+                // FeatureCollection();
+                // featureCollection.setGmlId("sampledFeatures_" +
+                // absFeature.getGmlId());
+                // for (final AbstractFeature sampledFeature :
+                // sampFeat.getSampledFeatures()) {
+                // featureCollection.addMember(sampledFeature);
+                // }
+                // final XmlObject encodeObjectToXml =
+                // CodingHelper.encodeObjectToXml(GmlConstants.NS_GML_32,
+                // featureCollection);
+                // xbSampFeature.addNewSampledFeature().set(encodeObjectToXml);
+                // }
 
             } else {
                 xbSampFeature.addNewSampledFeature().setHref(OGCConstants.UNKNOWN);
@@ -246,9 +248,8 @@ public class SamplingEncoderv20 extends AbstractXmlEncoder<AbstractFeature> {
     }
 
     private void encodeShape(final ShapeType xbShape, final SamplingFeature sampFeat) throws OwsExceptionReport {
-        final Encoder<XmlObject, Geometry> encoder =
-                CodingRepository.getInstance().getEncoder(
-                        CodingHelper.getEncoderKey(GmlConstants.NS_GML_32, sampFeat.getGeometry()));
+        final Encoder<XmlObject, Geometry> encoder = CodingRepository.getInstance()
+                .getEncoder(CodingHelper.getEncoderKey(GmlConstants.NS_GML_32, sampFeat.getGeometry()));
         if (encoder != null) {
             final Map<HelperValues, String> gmlAdditionalValues =
                     new EnumMap<HelperValues, String>(HelperValues.class);
@@ -275,24 +276,26 @@ public class SamplingEncoderv20 extends AbstractXmlEncoder<AbstractFeature> {
             }
         }
     }
-    
-    private void addNameDescription(SFSpatialSamplingFeatureType xbSamplingFeature, SamplingFeature samplingFeature) throws OwsExceptionReport {
+
+    private void addNameDescription(SFSpatialSamplingFeatureType xbSamplingFeature, SamplingFeature samplingFeature)
+            throws OwsExceptionReport {
         if (xbSamplingFeature != null) {
-                if (samplingFeature.isSetName()) {
-                    removeExitingNames(xbSamplingFeature);
-                    for (org.n52.sos.ogc.gml.CodeType codeType : samplingFeature.getName()) {
-                        xbSamplingFeature.addNewName().set(CodingHelper.encodeObjectToXml(GmlConstants.NS_GML_32, codeType));
-                    }
+            if (samplingFeature.isSetName()) {
+                removeExitingNames(xbSamplingFeature);
+                for (org.n52.sos.ogc.gml.CodeType codeType : samplingFeature.getName()) {
+                    xbSamplingFeature.addNewName()
+                            .set(CodingHelper.encodeObjectToXml(GmlConstants.NS_GML_32, codeType));
                 }
-                if (samplingFeature.isSetDescription()) {
-                    if (!xbSamplingFeature.isSetDescription()) {
-                        xbSamplingFeature.addNewDescription();
-                    }
-                    xbSamplingFeature.getDescription().setStringValue(samplingFeature.getDescription());
+            }
+            if (samplingFeature.isSetDescription()) {
+                if (!xbSamplingFeature.isSetDescription()) {
+                    xbSamplingFeature.addNewDescription();
                 }
+                xbSamplingFeature.getDescription().setStringValue(samplingFeature.getDescription());
+            }
         }
     }
-    
+
     private void removeExitingNames(SFSpatialSamplingFeatureType xbSamplingFeature) {
         if (CollectionHelper.isNotNullOrEmpty(xbSamplingFeature.getNameArray())) {
             for (int i = 0; i < xbSamplingFeature.getNameArray().length; i++) {

--- a/core/api/src/main/java/org/n52/sos/ogc/sensorML/elements/AbstractDataComponentContainer.java
+++ b/core/api/src/main/java/org/n52/sos/ogc/sensorML/elements/AbstractDataComponentContainer.java
@@ -28,6 +28,7 @@
  */
 package org.n52.sos.ogc.sensorML.elements;
 
+import org.n52.sos.ogc.gml.AbstractReferenceType;
 import org.n52.sos.ogc.swe.SweAbstractDataComponent;
 
 /**
@@ -39,7 +40,7 @@ import org.n52.sos.ogc.swe.SweAbstractDataComponent;
  * @param <T>
  *            Implemented class
  */
-public class AbstractDataComponentContainer<T> {
+public class AbstractDataComponentContainer<T> extends AbstractReferenceType {
 
     private String name;
 

--- a/core/api/src/main/java/org/n52/sos/ogc/sensorML/elements/AbstractSmlDataComponentContainer.java
+++ b/core/api/src/main/java/org/n52/sos/ogc/sensorML/elements/AbstractSmlDataComponentContainer.java
@@ -31,6 +31,7 @@ package org.n52.sos.ogc.sensorML.elements;
 import java.util.Collections;
 import java.util.Set;
 
+import org.n52.sos.ogc.gml.AbstractReferenceType;
 import org.n52.sos.ogc.swe.DataRecord;
 import org.n52.sos.ogc.swe.SweAbstractDataComponent;
 import org.n52.sos.ogc.swe.SweField;
@@ -48,14 +49,14 @@ import com.google.common.collect.Sets;
  *
  * @param <T> Implemented class
  */
-public class AbstractSmlDataComponentContainer<T> {
+public class AbstractSmlDataComponentContainer<T> extends AbstractReferenceType {
 
     private String name;
 
     private String typeDefinition;
 
     private DataRecord dataRecord;
-
+    
     private Set<SweAbstractDataComponent> abstractDataComponents = Sets.newHashSet();
 
     public AbstractSmlDataComponentContainer() {


### PR DESCRIPTION
Add check if AbstractDataRecord/AbstractDataComponent is set.
Add check and support for xlink:href and xlink:title in de-/encoder.