### PR TITLE
Fixes #280 and Fixes #269 and move observation splitting

### DIFF
--- a/coding/sos-v20/src/main/java/org/n52/sos/encode/OmEncoderv20.java
+++ b/coding/sos-v20/src/main/java/org/n52/sos/encode/OmEncoderv20.java
@@ -487,8 +487,8 @@ public class OmEncoderv20 extends AbstractOmEncoderv20 {
             throw new NoApplicableCodeException().withMessage(
                     "Encoding of observation value of type \"%s\" failed. Result: %s",
                     observationValue.getValue() != null ? observationValue.getValue().getClass().getName()
-                            : observationValue.getValue(), encodedObj != null ? encodedObj.getClass().getName()
-                            : encodedObj);
+                            : observationValue.getValue(),
+                    encodedObj != null ? encodedObj.getClass().getName() : encodedObj);
         }
     }
 

--- a/converter/split-and-merge/src/main/java/org/n52/sos/converter/SplitMergeObservations.java
+++ b/converter/split-and-merge/src/main/java/org/n52/sos/converter/SplitMergeObservations.java
@@ -82,10 +82,10 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-public class SplitMergeObservations implements
-        RequestResponseModifier<AbstractServiceRequest<?>, AbstractServiceResponse> {
-	
-	private static final Logger LOGGER = LoggerFactory.getLogger(SplitMergeObservations.class);
+public class SplitMergeObservations
+        implements RequestResponseModifier<AbstractServiceRequest<?>, AbstractServiceResponse> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SplitMergeObservations.class);
 
     private static final Set<RequestResponseModifierKeyType> REQUEST_RESPONSE_MODIFIER_KEY_TYPES = getKeyTypes();
 
@@ -106,8 +106,8 @@ public class SplitMergeObservations implements
             for (String version : versions) {
                 for (AbstractServiceRequest<?> request : requestResponseMap.keySet()) {
                     keys.add(new RequestResponseModifierKeyType(service, version, request));
-                    keys.add(new RequestResponseModifierKeyType(service, version, request, requestResponseMap
-                            .get(request)));
+                    keys.add(new RequestResponseModifierKeyType(service, version, request,
+                            requestResponseMap.get(request)));
                 }
             }
         }
@@ -122,18 +122,18 @@ public class SplitMergeObservations implements
     @Override
     public AbstractServiceRequest<?> modifyRequest(AbstractServiceRequest<?> request) throws OwsExceptionReport {
         if (request instanceof InsertObservationRequest) {
-        	splitObservations((InsertObservationRequest)request);
+            splitObservations((InsertObservationRequest) request);
         }
         return request;
     }
-    
+
     private void splitObservations(InsertObservationRequest request) throws OwsExceptionReport {
-    	if (request.isSetExtensionSplitDataArrayIntoObservations()) {
+        if (request.isSetExtensionSplitDataArrayIntoObservations()) {
             splitDataArrayIntoObservations(request);
         }
-	}
+    }
 
-	private void splitDataArrayIntoObservations(final InsertObservationRequest request) throws OwsExceptionReport {
+    private void splitDataArrayIntoObservations(final InsertObservationRequest request) throws OwsExceptionReport {
         LOGGER.debug("Start splitting observations. Count: {}", request.getObservations().size());
         final Collection<OmObservation> finalObservationCollection = Sets.newHashSet();
         for (final OmObservation observation : request.getObservations()) {
@@ -172,27 +172,27 @@ public class SplitMergeObservations implements
                     }
                     // result time
                     if (resultTimeIndex == -1) {
-                        // use phenomenon time if outer observation's resultTime value
+                        // use phenomenon time if outer observation's resultTime
+                        // value
                         // or nilReason is "template"
-                        if ((!observation.isSetResultTime()
-                                || observation.isTemplateResultTime())
+                        if ((!observation.isSetResultTime() || observation.isTemplateResultTime())
                                 && phenomenonTime instanceof TimeInstant) {
                             newObservation.setResultTime((TimeInstant) phenomenonTime);
                         } else {
                             newObservation.setResultTime(observation.getResultTime());
                         }
                     } else {
-                        newObservation.setResultTime(new TimeInstant(DateTimeHelper.parseIsoString2DateTime(block
-                                .get(resultTimeIndex))));
+                        newObservation.setResultTime(
+                                new TimeInstant(DateTimeHelper.parseIsoString2DateTime(block.get(resultTimeIndex))));
                     }
                     if (observation.isSetParameter()) {
-                    	newObservation.setParameter(observation.getParameter());
+                        newObservation.setParameter(observation.getParameter());
                     }
                     // value
-                    final ObservationValue<?> value =
-                            createObservationResultValue(observationConstellation.getObservationType(),
-                                    block.get(resultValueIndex), phenomenonTime, ((SweDataRecord) sweDataArrayValue
-                                            .getValue().getElementType()).getFields().get(resultValueIndex));
+                    final ObservationValue<?> value = createObservationResultValue(
+                            observationConstellation.getObservationType(), block.get(resultValueIndex), phenomenonTime,
+                            ((SweDataRecord) sweDataArrayValue.getValue().getElementType()).getFields()
+                                    .get(resultValueIndex));
                     newObservation.setValue(value);
                     finalObservationCollection.add(newObservation);
                 }
@@ -203,7 +203,7 @@ public class SplitMergeObservations implements
         }
         request.setObservation(Lists.newArrayList(finalObservationCollection));
     }
-    
+
     private ObservationValue<?> createObservationResultValue(final String observationType, final String valueString,
             final Time phenomenonTime, final SweField resultDefinitionField) throws OwsExceptionReport {
         ObservationValue<?> value = null;
@@ -274,15 +274,16 @@ public class SplitMergeObservations implements
     public AbstractServiceResponse modifyResponse(AbstractServiceRequest<?> request, AbstractServiceResponse response)
             throws OwsExceptionReport {
         if (request instanceof GetObservationRequest && response instanceof GetObservationResponse) {
-            return mergeObservations((GetObservationRequest)request, (GetObservationResponse) response); 
+            return mergeObservations((GetObservationRequest) request, (GetObservationResponse) response);
         }
         if (response instanceof GetObservationResponse) {
             return mergeObservations((GetObservationResponse) response);
         }
         return response;
     }
-    
-    private AbstractServiceResponse mergeObservations(GetObservationRequest request, GetObservationResponse response) throws OwsExceptionReport {
+
+    private AbstractServiceResponse mergeObservations(GetObservationRequest request, GetObservationResponse response)
+            throws OwsExceptionReport {
         boolean checkForMergeObservationsInResponse = checkForMergeObservationsInResponse(request);
         request.setMergeObservationValues(checkForMergeObservationsInResponse);
         boolean checkEncoderForMergeObservations = checkEncoderForMergeObservations(response);
@@ -291,10 +292,10 @@ public class SplitMergeObservations implements
                 mergeObservationsWithSameConstellation(response);
             }
             response.setMergeObservations(true);
-        }        
+        }
         return response;
     }
-    
+
     private void mergeObservationsWithSameConstellation(GetObservationResponse response) {
         // TODO merge all observations with the same observationContellation
         // FIXME Failed to set the observation type to sweArrayObservation for
@@ -329,8 +330,8 @@ public class SplitMergeObservations implements
     private boolean checkEncoderForMergeObservations(GetObservationResponse response) throws OwsExceptionReport {
         if (response.isSetResponseFormat()) {
             ObservationEncoder<XmlObject, OmObservation> encoder =
-                    (ObservationEncoder<XmlObject, OmObservation>) CodingHelper.getEncoder(
-                            response.getResponseFormat(), new OmObservation());
+                    (ObservationEncoder<XmlObject, OmObservation>) CodingHelper
+                            .getEncoder(response.getResponseFormat(), new OmObservation());
             if (encoder.shouldObservationsWithSameXBeMerged()) {
                 return true;
             }
@@ -348,7 +349,7 @@ public class SplitMergeObservations implements
         }
         return response;
     }
-    
+
     private boolean checkForMergeObservationsInResponse(GetObservationRequest sosRequest) {
         if (getActiveProfile().isMergeValues() || isSetExtensionMergeObservationsToSweDataArray(sosRequest)) {
             return true;
@@ -357,11 +358,10 @@ public class SplitMergeObservations implements
     }
 
     private boolean isSetExtensionMergeObservationsToSweDataArray(final GetObservationRequest sosRequest) {
-        return sosRequest.isSetExtensions()
-                && sosRequest.getExtensions().isBooleanExtensionSet(
-                        Sos2Constants.Extensions.MergeObservationsIntoDataArray.name());
+        return sosRequest.isSetExtensions() && sosRequest.getExtensions()
+                .isBooleanExtensionSet(Sos2Constants.Extensions.MergeObservationsIntoDataArray.name());
     }
-    
+
     protected Profile getActiveProfile() {
         return Configurator.getInstance().getProfileHandler().getActiveProfile();
     }

--- a/converter/split-and-merge/src/main/java/org/n52/sos/converter/SplitMergeObservations.java
+++ b/converter/split-and-merge/src/main/java/org/n52/sos/converter/SplitMergeObservations.java
@@ -28,6 +28,7 @@
  */
 package org.n52.sos.converter;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -39,11 +40,29 @@ import org.n52.sos.convert.RequestResponseModifier;
 import org.n52.sos.convert.RequestResponseModifierFacilitator;
 import org.n52.sos.convert.RequestResponseModifierKeyType;
 import org.n52.sos.encode.ObservationEncoder;
+import org.n52.sos.exception.ows.NoApplicableCodeException;
+import org.n52.sos.ogc.gml.CodeWithAuthority;
+import org.n52.sos.ogc.gml.time.Time;
+import org.n52.sos.ogc.gml.time.TimeInstant;
+import org.n52.sos.ogc.om.AbstractPhenomenon;
+import org.n52.sos.ogc.om.ObservationValue;
+import org.n52.sos.ogc.om.OmConstants;
 import org.n52.sos.ogc.om.OmObservation;
+import org.n52.sos.ogc.om.OmObservationConstellation;
+import org.n52.sos.ogc.om.SingleObservationValue;
+import org.n52.sos.ogc.om.values.BooleanValue;
+import org.n52.sos.ogc.om.values.CategoryValue;
+import org.n52.sos.ogc.om.values.CountValue;
+import org.n52.sos.ogc.om.values.QuantityValue;
+import org.n52.sos.ogc.om.values.SweDataArrayValue;
+import org.n52.sos.ogc.om.values.TextValue;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
 import org.n52.sos.ogc.sos.Sos1Constants;
 import org.n52.sos.ogc.sos.Sos2Constants;
 import org.n52.sos.ogc.sos.SosConstants;
+import org.n52.sos.ogc.swe.SweDataRecord;
+import org.n52.sos.ogc.swe.SweField;
+import org.n52.sos.ogc.swe.simpleType.SweAbstractUomType;
 import org.n52.sos.request.AbstractServiceRequest;
 import org.n52.sos.request.GetObservationRequest;
 import org.n52.sos.request.InsertObservationRequest;
@@ -53,12 +72,20 @@ import org.n52.sos.response.InsertObservationResponse;
 import org.n52.sos.service.Configurator;
 import org.n52.sos.service.profile.Profile;
 import org.n52.sos.util.CodingHelper;
+import org.n52.sos.util.DateTimeHelper;
+import org.n52.sos.util.OMHelper;
+import org.n52.sos.util.http.HTTPStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 public class SplitMergeObservations implements
         RequestResponseModifier<AbstractServiceRequest<?>, AbstractServiceResponse> {
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(SplitMergeObservations.class);
 
     private static final Set<RequestResponseModifierKeyType> REQUEST_RESPONSE_MODIFIER_KEY_TYPES = getKeyTypes();
 
@@ -95,9 +122,152 @@ public class SplitMergeObservations implements
     @Override
     public AbstractServiceRequest<?> modifyRequest(AbstractServiceRequest<?> request) throws OwsExceptionReport {
         if (request instanceof InsertObservationRequest) {
-            // TODO
+        	splitObservations((InsertObservationRequest)request);
         }
         return request;
+    }
+    
+    private void splitObservations(InsertObservationRequest request) throws OwsExceptionReport {
+    	if (request.isSetExtensionSplitDataArrayIntoObservations()) {
+            splitDataArrayIntoObservations(request);
+        }
+	}
+
+	private void splitDataArrayIntoObservations(final InsertObservationRequest request) throws OwsExceptionReport {
+        LOGGER.debug("Start splitting observations. Count: {}", request.getObservations().size());
+        final Collection<OmObservation> finalObservationCollection = Sets.newHashSet();
+        for (final OmObservation observation : request.getObservations()) {
+            if (isSweArrayObservation(observation)) {
+                LOGGER.debug("Found SweArrayObservation to split.");
+                final SweDataArrayValue sweDataArrayValue = (SweDataArrayValue) observation.getValue().getValue();
+                final OmObservationConstellation observationConstellation = observation.getObservationConstellation();
+                int counter = 0;
+                final int resultTimeIndex =
+                        getResultTimeIndex((SweDataRecord) sweDataArrayValue.getValue().getElementType());
+                final int phenomenonTimeIndex =
+                        getPhenomenonTimeIndex((SweDataRecord) sweDataArrayValue.getValue().getElementType());
+                final int resultValueIndex =
+                        getResultValueIndex((SweDataRecord) sweDataArrayValue.getValue().getElementType(),
+                                observationConstellation.getObservableProperty());
+                observationConstellation.setObservationType(getObservationTypeFromElementType(
+                        (SweDataRecord) sweDataArrayValue.getValue().getElementType(),
+                        observationConstellation.getObservableProperty()));
+                // split into single observation
+                for (final List<String> block : sweDataArrayValue.getValue().getValues()) {
+                    LOGGER.debug("Processing block {}/{}", ++counter, sweDataArrayValue.getValue().getValues().size());
+                    final OmObservation newObservation = new OmObservation();
+                    newObservation.setObservationConstellation(observationConstellation);
+                    // identifier
+                    if (observation.isSetIdentifier()) {
+                        final CodeWithAuthority identifier = observation.getIdentifierCodeWithAuthority();
+                        identifier.setValue(identifier.getValue() + counter);
+                        newObservation.setIdentifier(identifier);
+                    }
+                    // phen time
+                    Time phenomenonTime;
+                    if (phenomenonTimeIndex == -1) {
+                        phenomenonTime = observation.getPhenomenonTime();
+                    } else {
+                        phenomenonTime = DateTimeHelper.parseIsoString2DateTime2Time(block.get(phenomenonTimeIndex));
+                    }
+                    // result time
+                    if (resultTimeIndex == -1) {
+                        // use phenomenon time if outer observation's resultTime value
+                        // or nilReason is "template"
+                        if ((!observation.isSetResultTime()
+                                || observation.isTemplateResultTime())
+                                && phenomenonTime instanceof TimeInstant) {
+                            newObservation.setResultTime((TimeInstant) phenomenonTime);
+                        } else {
+                            newObservation.setResultTime(observation.getResultTime());
+                        }
+                    } else {
+                        newObservation.setResultTime(new TimeInstant(DateTimeHelper.parseIsoString2DateTime(block
+                                .get(resultTimeIndex))));
+                    }
+                    if (observation.isSetParameter()) {
+                    	newObservation.setParameter(observation.getParameter());
+                    }
+                    // value
+                    final ObservationValue<?> value =
+                            createObservationResultValue(observationConstellation.getObservationType(),
+                                    block.get(resultValueIndex), phenomenonTime, ((SweDataRecord) sweDataArrayValue
+                                            .getValue().getElementType()).getFields().get(resultValueIndex));
+                    newObservation.setValue(value);
+                    finalObservationCollection.add(newObservation);
+                }
+            } else {
+                LOGGER.debug("Found non splittable observation");
+                finalObservationCollection.add(observation);
+            }
+        }
+        request.setObservation(Lists.newArrayList(finalObservationCollection));
+    }
+    
+    private ObservationValue<?> createObservationResultValue(final String observationType, final String valueString,
+            final Time phenomenonTime, final SweField resultDefinitionField) throws OwsExceptionReport {
+        ObservationValue<?> value = null;
+
+        if (observationType.equalsIgnoreCase(OmConstants.OBS_TYPE_TRUTH_OBSERVATION)) {
+            value = new SingleObservationValue<Boolean>(new BooleanValue(Boolean.parseBoolean(valueString)));
+        } else if (observationType.equalsIgnoreCase(OmConstants.OBS_TYPE_COUNT_OBSERVATION)) {
+            value = new SingleObservationValue<Integer>(new CountValue(Integer.parseInt(valueString)));
+        } else if (observationType.equalsIgnoreCase(OmConstants.OBS_TYPE_MEASUREMENT)) {
+            final QuantityValue quantity = new QuantityValue(Double.parseDouble(valueString));
+            quantity.setUnit(getUom(resultDefinitionField));
+            value = new SingleObservationValue<Double>(quantity);
+        } else if (observationType.equalsIgnoreCase(OmConstants.OBS_TYPE_CATEGORY_OBSERVATION)) {
+            final CategoryValue cat = new CategoryValue(valueString);
+            cat.setUnit(getUom(resultDefinitionField));
+            value = new SingleObservationValue<String>(cat);
+        } else if (observationType.equalsIgnoreCase(OmConstants.OBS_TYPE_TEXT_OBSERVATION)) {
+            value = new SingleObservationValue<String>(new TextValue(valueString));
+        }
+        // TODO Check for missing types
+        if (value != null) {
+            value.setPhenomenonTime(phenomenonTime);
+        } else {
+            throw new NoApplicableCodeException().withMessage("Observation type '{}' not supported.", observationType)
+                    .setStatus(HTTPStatus.BAD_REQUEST);
+        }
+        return value;
+    }
+
+    private String getUom(final SweField resultDefinitionField) {
+        return ((SweAbstractUomType<?>) resultDefinitionField.getElement()).getUom();
+    }
+
+    private int getResultValueIndex(final SweDataRecord elementTypeDataRecord,
+            final AbstractPhenomenon observableProperty) {
+        return elementTypeDataRecord.getFieldIndexByIdentifier(observableProperty.getIdentifier());
+    }
+
+    private int getPhenomenonTimeIndex(final SweDataRecord elementTypeDataRecord) {
+        return elementTypeDataRecord.getFieldIndexByIdentifier(OmConstants.PHENOMENON_TIME);
+    }
+
+    private int getResultTimeIndex(final SweDataRecord elementTypeDataRecord) {
+        return elementTypeDataRecord.getFieldIndexByIdentifier(OmConstants.PHEN_SAMPLING_TIME);
+    }
+
+    private String getObservationTypeFromElementType(final SweDataRecord elementTypeDataRecord,
+            final AbstractPhenomenon observableProperty) throws OwsExceptionReport {
+        for (final SweField sweField : elementTypeDataRecord.getFields()) {
+            if (sweField.getElement() != null && sweField.getElement().isSetDefinition()
+                    && sweField.getElement().getDefinition().equalsIgnoreCase(observableProperty.getIdentifier())) {
+                return OMHelper.getObservationTypeFrom(sweField.getElement());
+            }
+        }
+        throw new NoApplicableCodeException().withMessage(
+                "Not able to derive observation type from elementType element '{}' for observable property '{}'.",
+                elementTypeDataRecord, observableProperty).setStatus(HTTPStatus.BAD_REQUEST);
+    }
+
+    private boolean isSweArrayObservation(final OmObservation observation) {
+        return observation.getObservationConstellation().getObservationType()
+                .equalsIgnoreCase(OmConstants.OBS_TYPE_SWE_ARRAY_OBSERVATION)
+                && observation.getValue().getValue() instanceof SweDataArrayValue
+                && ((SweDataArrayValue) observation.getValue().getValue()).isSetValue();
     }
 
     @Override

--- a/core/api/src/main/java/org/n52/sos/ogc/om/OmObservation.java
+++ b/core/api/src/main/java/org/n52/sos/ogc/om/OmObservation.java
@@ -649,7 +649,7 @@ public class OmObservation extends AbstractFeature implements Serializable {
                 || (!isSetAdditionalMergeIndicator() && observation.isSetAdditionalMergeIndicator())) {
             merge = false;
         }
-        return getObservationConstellation().equals(observation.getObservationConstellation()) && merge;
+        return getObservationConstellation().equals(observation.getObservationConstellation()) && merge && getObservationConstellation().checkObservationTypeForMerging();
     }
-
+    
 }

--- a/core/api/src/main/java/org/n52/sos/ogc/om/OmObservationConstellation.java
+++ b/core/api/src/main/java/org/n52/sos/ogc/om/OmObservationConstellation.java
@@ -253,6 +253,7 @@ public class OmObservationConstellation implements Serializable, Cloneable {
      *            Observation constellation to chek
      * @return true if equals
      */
+    @Deprecated
     public boolean equalsExcludingObsProp(OmObservationConstellation toCheckObsConst) {
         return (procedure.equals(toCheckObsConst.getProcedure())
                 && featureOfInterest.equals(toCheckObsConst.getFeatureOfInterest())
@@ -260,11 +261,17 @@ public class OmObservationConstellation implements Serializable, Cloneable {
 
     }
 
-    private boolean checkObservationTypeForMerging() {
-        return (!observationType.equals(OmConstants.OBS_TYPE_MEASUREMENT)
-                && !observationType.equals(OmConstants.OBS_TYPE_CATEGORY_OBSERVATION) && !observationType
-                    .equals(OmConstants.OBS_TYPE_GEOMETRY_OBSERVATION));
-    }
+	/**
+	 * TODO change if currently not supported types could be merged.
+	 * 
+	 * @return <code>true</code>, if the observation can be merged
+	 */
+	public boolean checkObservationTypeForMerging() {
+		return (isSetObservationType() && !OmConstants.OBS_TYPE_SWE_ARRAY_OBSERVATION.equals(observationType)
+				&& !OmConstants.OBS_TYPE_COMPLEX_OBSERVATION.equals(observationType)
+				&& !OmConstants.OBS_TYPE_OBSERVATION.equals(observationType)
+				&& !OmConstants.OBS_TYPE_UNKNOWN.equals(observationType));
+	}
 
     public boolean isSetObservationType() {
         return observationType != null && !observationType.isEmpty();

--- a/core/api/src/main/java/org/n52/sos/ogc/om/OmObservationConstellation.java
+++ b/core/api/src/main/java/org/n52/sos/ogc/om/OmObservationConstellation.java
@@ -48,7 +48,9 @@ public class OmObservationConstellation implements Serializable, Cloneable {
     /** Identifier of the procedure by which the observation is made */
     private SosProcedureDescription procedure;
 
-    /** Identifier of the observableProperty to which the observation accords to */
+    /**
+     * Identifier of the observableProperty to which the observation accords to
+     */
     private AbstractPhenomenon observableProperty;
 
     /** Identifiers of the offerings to which this observation belongs */
@@ -242,8 +244,8 @@ public class OmObservationConstellation implements Serializable, Cloneable {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.procedure, Constants.HASH_CODE_19,this.observableProperty,
-                                this.offerings, Constants.HASH_CODE_43,this.featureOfInterest);
+        return Objects.hashCode(this.procedure, Constants.HASH_CODE_19, this.observableProperty, this.offerings,
+                Constants.HASH_CODE_43, this.featureOfInterest);
     }
 
     /**
@@ -261,17 +263,17 @@ public class OmObservationConstellation implements Serializable, Cloneable {
 
     }
 
-	/**
-	 * TODO change if currently not supported types could be merged.
-	 * 
-	 * @return <code>true</code>, if the observation can be merged
-	 */
-	public boolean checkObservationTypeForMerging() {
-		return (isSetObservationType() && !OmConstants.OBS_TYPE_SWE_ARRAY_OBSERVATION.equals(observationType)
-				&& !OmConstants.OBS_TYPE_COMPLEX_OBSERVATION.equals(observationType)
-				&& !OmConstants.OBS_TYPE_OBSERVATION.equals(observationType)
-				&& !OmConstants.OBS_TYPE_UNKNOWN.equals(observationType));
-	}
+    /**
+     * TODO change if currently not supported types could be merged.
+     * 
+     * @return <code>true</code>, if the observation can be merged
+     */
+    public boolean checkObservationTypeForMerging() {
+        return (isSetObservationType() && !OmConstants.OBS_TYPE_SWE_ARRAY_OBSERVATION.equals(observationType)
+                && !OmConstants.OBS_TYPE_COMPLEX_OBSERVATION.equals(observationType)
+                && !OmConstants.OBS_TYPE_OBSERVATION.equals(observationType)
+                && !OmConstants.OBS_TYPE_UNKNOWN.equals(observationType));
+    }
 
     public boolean isSetObservationType() {
         return observationType != null && !observationType.isEmpty();

--- a/core/api/src/main/java/org/n52/sos/request/InsertObservationRequest.java
+++ b/core/api/src/main/java/org/n52/sos/request/InsertObservationRequest.java
@@ -141,10 +141,9 @@ public class InsertObservationRequest extends AbstractServiceRequest<InsertObser
     public InsertObservationResponse getResponse() throws OwsExceptionReport {
         return (InsertObservationResponse) new InsertObservationResponse().set(this);
     }
-    
+
     public boolean isSetExtensionSplitDataArrayIntoObservations() {
-        return isSetExtensions()
-                && getExtensions().isBooleanExtensionSet(
-                        Sos2Constants.Extensions.SplitDataArrayIntoObservations.name());
+        return isSetExtensions() && getExtensions()
+                .isBooleanExtensionSet(Sos2Constants.Extensions.SplitDataArrayIntoObservations.name());
     }
 }

--- a/core/api/src/main/java/org/n52/sos/request/InsertObservationRequest.java
+++ b/core/api/src/main/java/org/n52/sos/request/InsertObservationRequest.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import org.n52.sos.ogc.om.OmObservation;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
+import org.n52.sos.ogc.sos.Sos2Constants;
 import org.n52.sos.ogc.sos.SosConstants;
 import org.n52.sos.response.InsertObservationResponse;
 import org.n52.sos.util.CollectionHelper;
@@ -139,5 +140,11 @@ public class InsertObservationRequest extends AbstractServiceRequest<InsertObser
     @Override
     public InsertObservationResponse getResponse() throws OwsExceptionReport {
         return (InsertObservationResponse) new InsertObservationResponse().set(this);
+    }
+    
+    public boolean isSetExtensionSplitDataArrayIntoObservations() {
+        return isSetExtensions()
+                && getExtensions().isBooleanExtensionSet(
+                        Sos2Constants.Extensions.SplitDataArrayIntoObservations.name());
     }
 }

--- a/core/api/src/test/java/org/n52/sos/ogc/om/OmObservationConstellationTest.java
+++ b/core/api/src/test/java/org/n52/sos/ogc/om/OmObservationConstellationTest.java
@@ -38,7 +38,6 @@ import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
-
 public class OmObservationConstellationTest {
 
     private final String PROCEDURE_ID = "http://sensors.portdebarcelona.cat/def/weather/procedure";
@@ -67,36 +66,36 @@ public class OmObservationConstellationTest {
                 .setFeatureOfInterest(new SamplingFeature(new CodeWithAuthority(FEATURE_2)))
                 .setObservableProperty(new OmObservableProperty(OBSERVABLE_PROPERTY_2));
     }
-    
+
     @Test
     public void shouldNotBeEqualHashCode() {
         assertThat(getFirstObservationConstellation().hashCode(), not(getSecondObservationConstellation().hashCode()));
     }
-    
+
     @Test
     public void testChecheckObservationTypeForMerging() {
-    	OmObservationConstellation ooc = new OmObservationConstellation();
-    	ooc.setObservationType(OmConstants.OBS_TYPE_MEASUREMENT);
-    	assertThat(ooc.checkObservationTypeForMerging(), is(true));
-    	ooc.setObservationType(OmConstants.OBS_TYPE_CATEGORY_OBSERVATION);
-    	assertThat(ooc.checkObservationTypeForMerging(), is(true));
-    	ooc.setObservationType(OmConstants.OBS_TYPE_COUNT_OBSERVATION);
-    	assertThat(ooc.checkObservationTypeForMerging(), is(true));
-    	ooc.setObservationType(OmConstants.OBS_TYPE_GEOMETRY_OBSERVATION);
-    	assertThat(ooc.checkObservationTypeForMerging(), is(true));
-    	ooc.setObservationType(OmConstants.OBS_TYPE_TEXT_OBSERVATION);
-    	assertThat(ooc.checkObservationTypeForMerging(), is(true));
-    	ooc.setObservationType(OmConstants.OBS_TYPE_TRUTH_OBSERVATION);
-    	assertThat(ooc.checkObservationTypeForMerging(), is(true));
-    	ooc.setObservationType(OmConstants.OBS_TYPE_SWE_ARRAY_OBSERVATION);
-    	assertThat(ooc.checkObservationTypeForMerging(), is(false));
-    	ooc.setObservationType(OmConstants.OBS_TYPE_COMPLEX_OBSERVATION);
-    	assertThat(ooc.checkObservationTypeForMerging(), is(false));
-    	ooc.setObservationType(OmConstants.OBS_TYPE_OBSERVATION);
-    	assertThat(ooc.checkObservationTypeForMerging(), is(false));
-    	ooc.setObservationType(OmConstants.OBS_TYPE_UNKNOWN);
-    	assertThat(ooc.checkObservationTypeForMerging(), is(false));
-    	
+        OmObservationConstellation ooc = new OmObservationConstellation();
+        ooc.setObservationType(OmConstants.OBS_TYPE_MEASUREMENT);
+        assertThat(ooc.checkObservationTypeForMerging(), is(true));
+        ooc.setObservationType(OmConstants.OBS_TYPE_CATEGORY_OBSERVATION);
+        assertThat(ooc.checkObservationTypeForMerging(), is(true));
+        ooc.setObservationType(OmConstants.OBS_TYPE_COUNT_OBSERVATION);
+        assertThat(ooc.checkObservationTypeForMerging(), is(true));
+        ooc.setObservationType(OmConstants.OBS_TYPE_GEOMETRY_OBSERVATION);
+        assertThat(ooc.checkObservationTypeForMerging(), is(true));
+        ooc.setObservationType(OmConstants.OBS_TYPE_TEXT_OBSERVATION);
+        assertThat(ooc.checkObservationTypeForMerging(), is(true));
+        ooc.setObservationType(OmConstants.OBS_TYPE_TRUTH_OBSERVATION);
+        assertThat(ooc.checkObservationTypeForMerging(), is(true));
+        ooc.setObservationType(OmConstants.OBS_TYPE_SWE_ARRAY_OBSERVATION);
+        assertThat(ooc.checkObservationTypeForMerging(), is(false));
+        ooc.setObservationType(OmConstants.OBS_TYPE_COMPLEX_OBSERVATION);
+        assertThat(ooc.checkObservationTypeForMerging(), is(false));
+        ooc.setObservationType(OmConstants.OBS_TYPE_OBSERVATION);
+        assertThat(ooc.checkObservationTypeForMerging(), is(false));
+        ooc.setObservationType(OmConstants.OBS_TYPE_UNKNOWN);
+        assertThat(ooc.checkObservationTypeForMerging(), is(false));
+
     }
 
 }

--- a/core/api/src/test/java/org/n52/sos/ogc/om/OmObservationConstellationTest.java
+++ b/core/api/src/test/java/org/n52/sos/ogc/om/OmObservationConstellationTest.java
@@ -35,7 +35,9 @@ import org.n52.sos.ogc.sensorML.SensorML;
 import org.n52.sos.ogc.sos.SosProcedureDescription;
 
 import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
+
 
 public class OmObservationConstellationTest {
 
@@ -69,7 +71,32 @@ public class OmObservationConstellationTest {
     @Test
     public void shouldNotBeEqualHashCode() {
         assertThat(getFirstObservationConstellation().hashCode(), not(getSecondObservationConstellation().hashCode()));
-
+    }
+    
+    @Test
+    public void testChecheckObservationTypeForMerging() {
+    	OmObservationConstellation ooc = new OmObservationConstellation();
+    	ooc.setObservationType(OmConstants.OBS_TYPE_MEASUREMENT);
+    	assertThat(ooc.checkObservationTypeForMerging(), is(true));
+    	ooc.setObservationType(OmConstants.OBS_TYPE_CATEGORY_OBSERVATION);
+    	assertThat(ooc.checkObservationTypeForMerging(), is(true));
+    	ooc.setObservationType(OmConstants.OBS_TYPE_COUNT_OBSERVATION);
+    	assertThat(ooc.checkObservationTypeForMerging(), is(true));
+    	ooc.setObservationType(OmConstants.OBS_TYPE_GEOMETRY_OBSERVATION);
+    	assertThat(ooc.checkObservationTypeForMerging(), is(true));
+    	ooc.setObservationType(OmConstants.OBS_TYPE_TEXT_OBSERVATION);
+    	assertThat(ooc.checkObservationTypeForMerging(), is(true));
+    	ooc.setObservationType(OmConstants.OBS_TYPE_TRUTH_OBSERVATION);
+    	assertThat(ooc.checkObservationTypeForMerging(), is(true));
+    	ooc.setObservationType(OmConstants.OBS_TYPE_SWE_ARRAY_OBSERVATION);
+    	assertThat(ooc.checkObservationTypeForMerging(), is(false));
+    	ooc.setObservationType(OmConstants.OBS_TYPE_COMPLEX_OBSERVATION);
+    	assertThat(ooc.checkObservationTypeForMerging(), is(false));
+    	ooc.setObservationType(OmConstants.OBS_TYPE_OBSERVATION);
+    	assertThat(ooc.checkObservationTypeForMerging(), is(false));
+    	ooc.setObservationType(OmConstants.OBS_TYPE_UNKNOWN);
+    	assertThat(ooc.checkObservationTypeForMerging(), is(false));
+    	
     }
 
 }

--- a/hibernate/dao/pom.xml
+++ b/hibernate/dao/pom.xml
@@ -34,6 +34,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>split-and-merge</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>hibernate-h2</artifactId>
             <scope>test</scope>
         </dependency>

--- a/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/values/AbstractHibernateStreamingValue.java
+++ b/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/values/AbstractHibernateStreamingValue.java
@@ -38,6 +38,7 @@ import org.hibernate.criterion.Criterion;
 import org.joda.time.DateTime;
 import org.n52.sos.ds.hibernate.HibernateSessionHolder;
 import org.n52.sos.ds.hibernate.entities.AbstractObservationTime;
+import org.n52.sos.ds.hibernate.entities.interfaces.SweDataArrayValue;
 import org.n52.sos.ds.hibernate.entities.values.AbstractValue;
 import org.n52.sos.ogc.gml.time.Time;
 import org.n52.sos.ogc.gml.time.TimeInstant;
@@ -80,13 +81,18 @@ public abstract class AbstractHibernateStreamingValue extends StreamingValue<Abs
         Map<String, OmObservation> observations = Maps.newHashMap();
         while (hasNextValue()) {
             AbstractValue nextEntity = nextEntity();
+            boolean mergableObservationValue = checkForMergability(nextEntity);
             OmObservation observation = null;
-            if (observations.containsKey(nextEntity.getDiscriminator())) {
+            if (observations.containsKey(nextEntity.getDiscriminator()) && mergableObservationValue) {
                 observation = observations.get(nextEntity.getDiscriminator());
             } else {
                 observation = observationTemplate.cloneTemplate();
                 addSpecificValuesToObservation(observation, nextEntity, request.getExtensions());
-                observations.put(nextEntity.getDiscriminator(), observation);
+                if (!mergableObservationValue && nextEntity.getDiscriminator() == null) {
+                	observations.put(Long.toString(nextEntity.getObservationId()), observation);
+                } else {
+                	observations.put(nextEntity.getDiscriminator(), observation);
+                }
             }
             nextEntity.mergeValueToObservation(observation, getResponseFormat());
             sessionHolder.getSession().evict(nextEntity);
@@ -94,7 +100,11 @@ public abstract class AbstractHibernateStreamingValue extends StreamingValue<Abs
         return observations.values();
     }
 
-    private void addSpecificValuesToObservation(OmObservation observation, AbstractValue value, SwesExtensions swesExtensions) {
+    private boolean checkForMergability(AbstractValue nextEntity) {
+		return !(nextEntity instanceof SweDataArrayValue);
+	}
+
+	private void addSpecificValuesToObservation(OmObservation observation, AbstractValue value, SwesExtensions swesExtensions) {
         boolean newSession = false;
         try {
             if (session == null) {

--- a/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/values/AbstractHibernateStreamingValue.java
+++ b/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/values/AbstractHibernateStreamingValue.java
@@ -89,9 +89,9 @@ public abstract class AbstractHibernateStreamingValue extends StreamingValue<Abs
                 observation = observationTemplate.cloneTemplate();
                 addSpecificValuesToObservation(observation, nextEntity, request.getExtensions());
                 if (!mergableObservationValue && nextEntity.getDiscriminator() == null) {
-                	observations.put(Long.toString(nextEntity.getObservationId()), observation);
+                    observations.put(Long.toString(nextEntity.getObservationId()), observation);
                 } else {
-                	observations.put(nextEntity.getDiscriminator(), observation);
+                    observations.put(nextEntity.getDiscriminator(), observation);
                 }
             }
             nextEntity.mergeValueToObservation(observation, getResponseFormat());
@@ -101,10 +101,11 @@ public abstract class AbstractHibernateStreamingValue extends StreamingValue<Abs
     }
 
     private boolean checkForMergability(AbstractValue nextEntity) {
-		return !(nextEntity instanceof SweDataArrayValue);
-	}
+        return !(nextEntity instanceof SweDataArrayValue);
+    }
 
-	private void addSpecificValuesToObservation(OmObservation observation, AbstractValue value, SwesExtensions swesExtensions) {
+    private void addSpecificValuesToObservation(OmObservation observation, AbstractValue value,
+            SwesExtensions swesExtensions) {
         boolean newSession = false;
         try {
             if (session == null) {

--- a/hibernate/dao/src/test/java/org/n52/sos/ds/hibernate/InsertDAOTest.java
+++ b/hibernate/dao/src/test/java/org/n52/sos/ds/hibernate/InsertDAOTest.java
@@ -33,10 +33,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import net.opengis.sensorML.x101.SystemDocument;
-import net.opengis.swe.x20.DataRecordDocument;
-import net.opengis.swe.x20.TextEncodingDocument;
-
 import org.hibernate.Session;
 import org.joda.time.DateTime;
 import org.junit.After;
@@ -113,10 +109,13 @@ import org.n52.sos.response.InsertSensorResponse;
 import org.n52.sos.service.Configurator;
 import org.n52.sos.util.CodingHelper;
 import org.n52.sos.util.CollectionHelper;
-import org.n52.sos.util.Constants;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
+import net.opengis.sensorML.x101.SystemDocument;
+import net.opengis.swe.x20.DataRecordDocument;
+import net.opengis.swe.x20.TextEncodingDocument;
 
 /**
  * Test various Insert*DAOs using a common set of test data with hierarchical

--- a/hibernate/dao/src/test/java/org/n52/sos/ds/hibernate/InsertDAOTest.java
+++ b/hibernate/dao/src/test/java/org/n52/sos/ds/hibernate/InsertDAOTest.java
@@ -563,7 +563,7 @@ public class InsertDAOTest extends HibernateTestCase {
         obsVal.setValue(sweDataArrayValue);
         obs.setValue(obsVal);
         req.setObservation(Lists.newArrayList(obs));
-        insertObservationOperatorv2.receive(req);
+        insertObservationOperatorv2.receiveRequest(req);
         assertInsertionAftermathBeforeAndAfterCacheReload();
 
         checkObservation(OFFERING3, PROCEDURE3, OBSPROP3, TIME1, PROCEDURE3, OBSPROP3, FEATURE3, VAL1, TEMP_UNIT);

--- a/operations/transactional-v20/src/main/java/org/n52/sos/request/operator/SosInsertObservationOperatorV20.java
+++ b/operations/transactional-v20/src/main/java/org/n52/sos/request/operator/SosInsertObservationOperatorV20.java
@@ -30,7 +30,6 @@ package org.n52.sos.request.operator;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 
 import org.n52.sos.cache.ContentCache;
@@ -45,45 +44,22 @@ import org.n52.sos.exception.ows.concrete.InvalidObservationTypeForOfferingExcep
 import org.n52.sos.exception.ows.concrete.InvalidOfferingParameterException;
 import org.n52.sos.exception.ows.concrete.MissingObservationParameterException;
 import org.n52.sos.exception.ows.concrete.MissingOfferingParameterException;
-import org.n52.sos.ogc.gml.CodeWithAuthority;
-import org.n52.sos.ogc.gml.time.Time;
-import org.n52.sos.ogc.gml.time.TimeInstant;
-import org.n52.sos.ogc.om.AbstractPhenomenon;
 import org.n52.sos.ogc.om.NamedValue;
-import org.n52.sos.ogc.om.ObservationValue;
-import org.n52.sos.ogc.om.OmConstants;
 import org.n52.sos.ogc.om.OmObservation;
 import org.n52.sos.ogc.om.OmObservationConstellation;
-import org.n52.sos.ogc.om.SingleObservationValue;
-import org.n52.sos.ogc.om.values.BooleanValue;
-import org.n52.sos.ogc.om.values.CategoryValue;
-import org.n52.sos.ogc.om.values.CountValue;
-import org.n52.sos.ogc.om.values.QuantityValue;
-import org.n52.sos.ogc.om.values.SweDataArrayValue;
-import org.n52.sos.ogc.om.values.TextValue;
 import org.n52.sos.ogc.ows.CompositeOwsException;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
 import org.n52.sos.ogc.sos.ConformanceClasses;
 import org.n52.sos.ogc.sos.Sos2Constants;
 import org.n52.sos.ogc.sos.SosConstants;
-import org.n52.sos.ogc.swe.SweDataRecord;
-import org.n52.sos.ogc.swe.SweField;
-import org.n52.sos.ogc.swe.simpleType.SweAbstractUomType;
 import org.n52.sos.ogc.swes.SwesExtensions;
 import org.n52.sos.request.InsertObservationRequest;
 import org.n52.sos.response.InsertObservationResponse;
 import org.n52.sos.service.Configurator;
 import org.n52.sos.util.CollectionHelper;
-import org.n52.sos.util.DateTimeHelper;
 import org.n52.sos.util.OMHelper;
-import org.n52.sos.util.http.HTTPStatus;
 import org.n52.sos.wsdl.WSDLConstants;
 import org.n52.sos.wsdl.WSDLOperation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 /**
  * @since 4.0.0
@@ -91,8 +67,6 @@ import com.google.common.collect.Sets;
  */
 public class SosInsertObservationOperatorV20 extends
         AbstractV2TransactionalRequestOperator<AbstractInsertObservationDAO, InsertObservationRequest, InsertObservationResponse> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(SosInsertObservationOperatorV20.class);
 
     private static final String OPERATION_NAME = SosConstants.Operations.InsertObservation.name();
 
@@ -110,155 +84,9 @@ public class SosInsertObservationOperatorV20 extends
 
     @Override
     public InsertObservationResponse receive(final InsertObservationRequest request) throws OwsExceptionReport {
-        if (isSetExtensionSplitDataArrayIntoObservations(request)) {
-            splitDataArrayIntoObservations(request);
-        }
         InsertObservationResponse response = getDao().insertObservation(request);
         SosEventBus.fire(new ObservationInsertion(request, response));
         return response;
-    }
-
-    private void splitDataArrayIntoObservations(final InsertObservationRequest request) throws OwsExceptionReport {
-        LOGGER.debug("Start splitting observations. Count: {}", request.getObservations().size());
-        final Collection<OmObservation> finalObservationCollection = Sets.newHashSet();
-        for (final OmObservation observation : request.getObservations()) {
-            if (isSweArrayObservation(observation)) {
-                LOGGER.debug("Found SweArrayObservation to split.");
-                final SweDataArrayValue sweDataArrayValue = (SweDataArrayValue) observation.getValue().getValue();
-                final OmObservationConstellation observationConstellation = observation.getObservationConstellation();
-                int counter = 0;
-                final int resultTimeIndex =
-                        getResultTimeIndex((SweDataRecord) sweDataArrayValue.getValue().getElementType());
-                final int phenomenonTimeIndex =
-                        getPhenomenonTimeIndex((SweDataRecord) sweDataArrayValue.getValue().getElementType());
-                final int resultValueIndex =
-                        getResultValueIndex((SweDataRecord) sweDataArrayValue.getValue().getElementType(),
-                                observationConstellation.getObservableProperty());
-                observationConstellation.setObservationType(getObservationTypeFromElementType(
-                        (SweDataRecord) sweDataArrayValue.getValue().getElementType(),
-                        observationConstellation.getObservableProperty()));
-                // split into single observation
-                for (final List<String> block : sweDataArrayValue.getValue().getValues()) {
-                    LOGGER.debug("Processing block {}/{}", ++counter, sweDataArrayValue.getValue().getValues().size());
-                    final OmObservation newObservation = new OmObservation();
-                    newObservation.setObservationConstellation(observationConstellation);
-                    // identifier
-                    if (observation.isSetIdentifier()) {
-                        final CodeWithAuthority identifier = observation.getIdentifierCodeWithAuthority();
-                        identifier.setValue(identifier.getValue() + counter);
-                        newObservation.setIdentifier(identifier);
-                    }
-                    // phen time
-                    Time phenomenonTime;
-                    if (phenomenonTimeIndex == -1) {
-                        phenomenonTime = observation.getPhenomenonTime();
-                    } else {
-                        phenomenonTime = DateTimeHelper.parseIsoString2DateTime2Time(block.get(phenomenonTimeIndex));
-                    }
-                    // result time
-                    if (resultTimeIndex == -1) {
-                        // use phenomenon time if outer observation's resultTime value
-                        // or nilReason is "template"
-                        if ((!observation.isSetResultTime()
-                                || observation.isTemplateResultTime())
-                                && phenomenonTime instanceof TimeInstant) {
-                            newObservation.setResultTime((TimeInstant) phenomenonTime);
-                        } else {
-                            newObservation.setResultTime(observation.getResultTime());
-                        }
-                    } else {
-                        newObservation.setResultTime(new TimeInstant(DateTimeHelper.parseIsoString2DateTime(block
-                                .get(resultTimeIndex))));
-                    }
-                    if (observation.isSetParameter()) {
-                    	newObservation.setParameter(observation.getParameter());
-                    }
-                    // value
-                    final ObservationValue<?> value =
-                            createObservationResultValue(observationConstellation.getObservationType(),
-                                    block.get(resultValueIndex), phenomenonTime, ((SweDataRecord) sweDataArrayValue
-                                            .getValue().getElementType()).getFields().get(resultValueIndex));
-                    newObservation.setValue(value);
-                    finalObservationCollection.add(newObservation);
-                }
-            } else {
-                LOGGER.debug("Found non splittable observation");
-                finalObservationCollection.add(observation);
-            }
-        }
-        request.setObservation(Lists.newArrayList(finalObservationCollection));
-    }
-
-    private ObservationValue<?> createObservationResultValue(final String observationType, final String valueString,
-            final Time phenomenonTime, final SweField resultDefinitionField) throws OwsExceptionReport {
-        ObservationValue<?> value = null;
-
-        if (observationType.equalsIgnoreCase(OmConstants.OBS_TYPE_TRUTH_OBSERVATION)) {
-            value = new SingleObservationValue<Boolean>(new BooleanValue(Boolean.parseBoolean(valueString)));
-        } else if (observationType.equalsIgnoreCase(OmConstants.OBS_TYPE_COUNT_OBSERVATION)) {
-            value = new SingleObservationValue<Integer>(new CountValue(Integer.parseInt(valueString)));
-        } else if (observationType.equalsIgnoreCase(OmConstants.OBS_TYPE_MEASUREMENT)) {
-            final QuantityValue quantity = new QuantityValue(Double.parseDouble(valueString));
-            quantity.setUnit(getUom(resultDefinitionField));
-            value = new SingleObservationValue<Double>(quantity);
-        } else if (observationType.equalsIgnoreCase(OmConstants.OBS_TYPE_CATEGORY_OBSERVATION)) {
-            final CategoryValue cat = new CategoryValue(valueString);
-            cat.setUnit(getUom(resultDefinitionField));
-            value = new SingleObservationValue<String>(cat);
-        } else if (observationType.equalsIgnoreCase(OmConstants.OBS_TYPE_TEXT_OBSERVATION)) {
-            value = new SingleObservationValue<String>(new TextValue(valueString));
-        }
-        // TODO Check for missing types
-        if (value != null) {
-            value.setPhenomenonTime(phenomenonTime);
-        } else {
-            throw new NoApplicableCodeException().withMessage("Observation type '{}' not supported.", observationType)
-                    .setStatus(HTTPStatus.BAD_REQUEST);
-        }
-        return value;
-    }
-
-    private String getUom(final SweField resultDefinitionField) {
-        return ((SweAbstractUomType<?>) resultDefinitionField.getElement()).getUom();
-    }
-
-    private int getResultValueIndex(final SweDataRecord elementTypeDataRecord,
-            final AbstractPhenomenon observableProperty) {
-        return elementTypeDataRecord.getFieldIndexByIdentifier(observableProperty.getIdentifier());
-    }
-
-    private int getPhenomenonTimeIndex(final SweDataRecord elementTypeDataRecord) {
-        return elementTypeDataRecord.getFieldIndexByIdentifier(OmConstants.PHENOMENON_TIME);
-    }
-
-    private int getResultTimeIndex(final SweDataRecord elementTypeDataRecord) {
-        return elementTypeDataRecord.getFieldIndexByIdentifier(OmConstants.PHEN_SAMPLING_TIME);
-    }
-
-    private String getObservationTypeFromElementType(final SweDataRecord elementTypeDataRecord,
-            final AbstractPhenomenon observableProperty) throws OwsExceptionReport {
-        for (final SweField sweField : elementTypeDataRecord.getFields()) {
-            if (sweField.getElement() != null && sweField.getElement().isSetDefinition()
-                    && sweField.getElement().getDefinition().equalsIgnoreCase(observableProperty.getIdentifier())) {
-                return OMHelper.getObservationTypeFrom(sweField.getElement());
-            }
-        }
-        throw new NoApplicableCodeException().withMessage(
-                "Not able to derive observation type from elementType element '{}' for observable property '{}'.",
-                elementTypeDataRecord, observableProperty).setStatus(HTTPStatus.BAD_REQUEST);
-    }
-
-    private boolean isSweArrayObservation(final OmObservation observation) {
-        return observation.getObservationConstellation().getObservationType()
-                .equalsIgnoreCase(OmConstants.OBS_TYPE_SWE_ARRAY_OBSERVATION)
-                && observation.getValue().getValue() instanceof SweDataArrayValue
-                && ((SweDataArrayValue) observation.getValue().getValue()).isSetValue();
-    }
-
-    private boolean isSetExtensionSplitDataArrayIntoObservations(final InsertObservationRequest request) {
-        return request.isSetExtensions()
-                && request.getExtensions().isBooleanExtensionSet(
-                        Sos2Constants.Extensions.SplitDataArrayIntoObservations.name());
     }
 
     @Override
@@ -361,7 +189,7 @@ public class SosInsertObservationOperatorV20 extends
                         final Collection<String> allowedObservationTypes =
                                 cache.getAllowedObservationTypesForOffering(offeringID);
                         if ((allowedObservationTypes == null || !allowedObservationTypes.contains(obsConstallation
-                                .getObservationType())) && !isSetExtensionSplitDataArrayIntoObservations(request)) {
+                                .getObservationType())) && !request.isSetExtensionSplitDataArrayIntoObservations()) {
                             exceptions.add(new InvalidObservationTypeForOfferingException(obsConstallation
                                     .getObservationType(), offeringID));
                         }

--- a/operations/transactional-v20/src/main/java/org/n52/sos/request/operator/SosInsertObservationOperatorV20.java
+++ b/operations/transactional-v20/src/main/java/org/n52/sos/request/operator/SosInsertObservationOperatorV20.java
@@ -70,8 +70,8 @@ public class SosInsertObservationOperatorV20 extends
 
     private static final String OPERATION_NAME = SosConstants.Operations.InsertObservation.name();
 
-    private static final Set<String> CONFORMANCE_CLASSES = Collections
-            .singleton(ConformanceClasses.SOS_V2_OBSERVATION_INSERTION);
+    private static final Set<String> CONFORMANCE_CLASSES =
+            Collections.singleton(ConformanceClasses.SOS_V2_OBSERVATION_INSERTION);
 
     public SosInsertObservationOperatorV20() {
         super(OPERATION_NAME, InsertObservationRequest.class);
@@ -121,7 +121,7 @@ public class SosInsertObservationOperatorV20 extends
         }
         exceptions.throwIfNotEmpty();
     }
-    
+
     /**
      * Check if the observation contains more than one sampling geometry
      * definitions.
@@ -136,7 +136,8 @@ public class SosInsertObservationOperatorV20 extends
             if (observation.isSetParameter()) {
                 int count = 0;
                 for (NamedValue<?> namedValue : observation.getParameter()) {
-                    if (Sos2Constants.HREF_PARAMETER_SPATIAL_FILTERING_PROFILE.equals(namedValue.getName().getHref())) {
+                    if (Sos2Constants.HREF_PARAMETER_SPATIAL_FILTERING_PROFILE
+                            .equals(namedValue.getName().getHref())) {
                         count++;
                     }
                 }
@@ -146,7 +147,6 @@ public class SosInsertObservationOperatorV20 extends
                 }
             }
         }
-
     }
 
     private void checkAndAddOfferingToObservationConstallation(final InsertObservationRequest request)
@@ -188,10 +188,11 @@ public class SosInsertObservationOperatorV20 extends
                     for (final String offeringID : obsConstallation.getOfferings()) {
                         final Collection<String> allowedObservationTypes =
                                 cache.getAllowedObservationTypesForOffering(offeringID);
-                        if ((allowedObservationTypes == null || !allowedObservationTypes.contains(obsConstallation
-                                .getObservationType())) && !request.isSetExtensionSplitDataArrayIntoObservations()) {
-                            exceptions.add(new InvalidObservationTypeForOfferingException(obsConstallation
-                                    .getObservationType(), offeringID));
+                        if ((allowedObservationTypes == null
+                                || !allowedObservationTypes.contains(obsConstallation.getObservationType()))
+                                && !request.isSetExtensionSplitDataArrayIntoObservations()) {
+                            exceptions.add(new InvalidObservationTypeForOfferingException(
+                                    obsConstallation.getObservationType(), offeringID));
                         }
                     }
                 }
@@ -201,20 +202,18 @@ public class SosInsertObservationOperatorV20 extends
     }
 
     private boolean isSplitObservations(final SwesExtensions swesExtensions) {
-        return swesExtensions != null
-                && !swesExtensions.isEmpty()
-                && swesExtensions
-                        .isBooleanExtensionSet(Sos2Constants.Extensions.SplitDataArrayIntoObservations.name());
+        return swesExtensions != null && !swesExtensions.isEmpty() && swesExtensions
+                .isBooleanExtensionSet(Sos2Constants.Extensions.SplitDataArrayIntoObservations.name());
     }
 
     private void checkObservationConstellationParameter(final OmObservationConstellation obsConstallation)
             throws OwsExceptionReport {
-		checkProcedureID(obsConstallation.getProcedure().getIdentifier(),
-				Sos2Constants.InsertObservationParams.procedure.name());
-		checkObservedProperty(obsConstallation.getObservableProperty().getIdentifier(),
-				Sos2Constants.InsertObservationParams.observedProperty.name());
-		checkReservedCharacter(obsConstallation.getFeatureOfInterest().getIdentifier(), 
-				Sos2Constants.InsertObservationParams.featureOfInterest);
+        checkProcedureID(obsConstallation.getProcedure().getIdentifier(),
+                Sos2Constants.InsertObservationParams.procedure.name());
+        checkObservedProperty(obsConstallation.getObservableProperty().getIdentifier(),
+                Sos2Constants.InsertObservationParams.observedProperty.name());
+        checkReservedCharacter(obsConstallation.getFeatureOfInterest().getIdentifier(),
+                Sos2Constants.InsertObservationParams.featureOfInterest);
     }
 
     private void checkOrSetObservationType(final OmObservation sosObservation, final boolean isSplitObservations)
@@ -226,10 +225,9 @@ public class SosInsertObservationOperatorV20 extends
                     Sos2Constants.InsertObservationParams.observationType.name());
             if (obsTypeFromValue != null
                     && !sosObservation.getObservationConstellation().getObservationType().equals(obsTypeFromValue)) {
-                throw new NoApplicableCodeException()
-                        .withMessage(
-                                "The requested observation is invalid! The result element does not comply with the defined type (%s)!",
-                                sosObservation.getObservationConstellation().getObservationType());
+                throw new NoApplicableCodeException().withMessage(
+                        "The requested observation is invalid! The result element does not comply with the defined type (%s)!",
+                        sosObservation.getObservationConstellation().getObservationType());
             }
         } else if (!isSplitObservations) {
             sosObservation.getObservationConstellation().setObservationType(obsTypeFromValue);


### PR DESCRIPTION
- Fix #280 : Exception or return single observations if GetObservation contains merge flag and observations are OM_SweArrayObservations
   - Return OM_SweArrayObservations as they are
- Move observation splitting to SplitMergeObservation class