### PR TITLE
Do not use TOffering.class in getOfferingObjectsForCacheUpdate()

### DIFF
--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/OfferingDAO.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/dao/OfferingDAO.java
@@ -111,21 +111,19 @@ public class OfferingDAO extends TimeCreator implements HibernateSqlQueryConstan
      * Get offering objects for cache update
      *
      * @param identifiers
-     *            Optional collection of offering identifiers to fetch. If null, all offerings are returned.
+     *            Optional collection of offering identifiers to fetch. If null,
+     *            all offerings are returned.
      * @param session
      *            Hibernate session
      * @return Offering objects
      */
     @SuppressWarnings("unchecked")
-    public List<Offering> getOfferingObjectsForCacheUpdate(final Collection<String> identifiers, final Session session) {
-    	 Class<?> clazz = Offering.class;
-    	 if (HibernateHelper.isEntitySupported(TOffering.class)) {
-    		 clazz = TOffering.class;
-    	 }
-    	 Criteria criteria = session.createCriteria(clazz);
-		if (CollectionHelper.isNotEmpty(identifiers)) {
-		    criteria.add(Restrictions.in(Offering.IDENTIFIER, identifiers));
-		}
+    public List<Offering> getOfferingObjectsForCacheUpdate(final Collection<String> identifiers,
+            final Session session) {
+        Criteria criteria = session.createCriteria(Offering.class);
+        if (CollectionHelper.isNotEmpty(identifiers)) {
+            criteria.add(Restrictions.in(Offering.IDENTIFIER, identifiers));
+        }
         LOGGER.debug("QUERY getOfferingObjectsForCacheUpdate(): {}", HibernateHelper.getSqlString(criteria));
         return criteria.list();
     }

--- a/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/cache/base/OfferingCacheUpdate.java
+++ b/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/cache/base/OfferingCacheUpdate.java
@@ -115,28 +115,24 @@ public class OfferingCacheUpdate extends AbstractQueueingDatasourceCacheUpdate<O
         //perform single threaded updates here
         WritableContentCache cache = getCache();
 
-        for (Offering offering : getOfferingsToUpdate()){
-//            try {
-                String offeringId = offering.getIdentifier();
-                if (shouldOfferingBeProcessed(offeringId)) {
-                    String prefixedOfferingId = CacheHelper.addPrefixOrGetOfferingIdentifier(offeringId);
-                    cache.addOffering(prefixedOfferingId);
+        for (Offering offering : getOfferingsToUpdate()) {
+            String offeringId = offering.getIdentifier();
+            if (shouldOfferingBeProcessed(offeringId)) {
+                String prefixedOfferingId = CacheHelper.addPrefixOrGetOfferingIdentifier(offeringId);
+                cache.addOffering(prefixedOfferingId);
 
-                    if (offering instanceof TOffering) {
-                        TOffering tOffering = (TOffering) offering;
-                        // Related features
-                        cache.setRelatedFeaturesForOffering(prefixedOfferingId,
-                                                             getRelatedFeatureIdentifiersFrom(tOffering));
-                        cache.setAllowedObservationTypeForOffering(prefixedOfferingId,
-                                                                    getObservationTypesFromObservationType(tOffering.getObservationTypes()));
-                        // featureOfInterestTypes
-                        cache.setAllowedFeatureOfInterestTypeForOffering(prefixedOfferingId,
-                                                                          getFeatureOfInterestTypesFromFeatureOfInterestType(tOffering.getFeatureOfInterestTypes()));
-                    }
+                if (offering instanceof TOffering) {
+                    TOffering tOffering = (TOffering) offering;
+                    // Related features
+                    cache.setRelatedFeaturesForOffering(prefixedOfferingId,
+                            getRelatedFeatureIdentifiersFrom(tOffering));
+                    cache.setAllowedObservationTypeForOffering(prefixedOfferingId,
+                            getObservationTypesFromObservationType(tOffering.getObservationTypes()));
+                    // featureOfInterestTypes
+                    cache.setAllowedFeatureOfInterestTypeForOffering(prefixedOfferingId,
+                            getFeatureOfInterestTypesFromFeatureOfInterestType(tOffering.getFeatureOfInterestTypes()));
                 }
-//            } catch (OwsExceptionReport ex) {
-//                getErrors().add(ex);
-//            }
+            }
         }
 
         //time ranges


### PR DESCRIPTION
Do not use TOffering.class in getOfferingObjectsForCacheUpdate() if entity is available because this returns only TOffering and not all Offerings.