### PR TITLE
Fix #351 Development Branch always 'enriching with discovery information'

### DIFF
--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/util/procedure/enrich/IdentificationEnrichment.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/util/procedure/enrich/IdentificationEnrichment.java
@@ -37,6 +37,7 @@ import org.n52.sos.ogc.ows.OwsExceptionReport;
 import org.n52.sos.ogc.sensorML.AbstractSensorML;
 import org.n52.sos.ogc.sensorML.SensorMLConstants;
 import org.n52.sos.ogc.sensorML.elements.SmlIdentifier;
+import org.n52.sos.service.ServiceConfiguration;
 
 import com.google.common.base.Optional;
 
@@ -154,7 +155,11 @@ public class IdentificationEnrichment extends SensorMLEnrichment {
 
     @Override
     public boolean isApplicable() {
-        return super.isApplicable() && (procedureSettings().isEnrichWithDiscoveryInformation() || isSetLocale());
+        return super.isApplicable() && (procedureSettings().isEnrichWithDiscoveryInformation() || isNotDefaultLocale());
+    }
+    
+    private boolean isNotDefaultLocale() {
+        return isSetLocale() && !getLocale().equals(ServiceConfiguration.getInstance().getDefaultLanguage());
     }
 
 }


### PR DESCRIPTION
The isApplicable check was not correct because it was true if the local is set. But the locale is always set with the default value. Add check if locale is not the default locale.