### PR TITLE
Fix #352 Duplicate TimePeriod gml:id entered OK, but stops DescribeSensor retrieval of 'parent' PhysicalProcess

### DIFF
--- a/coding/sensorML-v101/src/main/java/org/n52/sos/encode/SensorMLEncoderv101.java
+++ b/coding/sensorML-v101/src/main/java/org/n52/sos/encode/SensorMLEncoderv101.java
@@ -242,6 +242,8 @@ public class SensorMLEncoderv101 extends AbstractSensorMLEncoder {
         } else {
             throw new UnsupportedEncoderInputException(this, response);
         }
+        // check if all gml:id are unique
+        XmlHelper.makeGmlIdsUnique(encodedObject.getDomNode());
         LOGGER.debug("Encoded object {} is valid: {}", encodedObject.schemaType().toString(),
                 XmlHelper.validateDocument(encodedObject));
         return encodedObject;

--- a/coding/sensorML-v20/src/main/java/org/n52/sos/encode/SensorMLEncoderv20.java
+++ b/coding/sensorML-v20/src/main/java/org/n52/sos/encode/SensorMLEncoderv20.java
@@ -251,6 +251,8 @@ public class SensorMLEncoderv20 extends AbstractSensorMLEncoder {
         } catch (final XmlException xmle) {
             throw new NoApplicableCodeException().causedBy(xmle);
         }
+        // check if all gml:id are unique
+        XmlHelper.makeGmlIdsUnique(encodedObject.getDomNode());
         LOGGER.debug("Encoded object {} is valid: {}", encodedObject.schemaType().toString(),
                 XmlHelper.validateDocument(encodedObject));
         return encodedObject;

--- a/coding/sos-v20/src/main/java/org/n52/sos/encode/swes/DescribeSensorResponseEncoder.java
+++ b/coding/sos-v20/src/main/java/org/n52/sos/encode/swes/DescribeSensorResponseEncoder.java
@@ -83,6 +83,10 @@ public class DescribeSensorResponseEncoder extends AbstractSwesResponseEncoder<D
                 substitution.set(xmlObjectValidtime);
             }
         }
+        // in a single observation the gml:ids must be unique
+        if (response.getProcedureDescriptions().size() > 1) {
+            XmlHelper.makeGmlIdsUnique(doc.getDomNode());
+        }
         return doc;
     }
 


### PR DESCRIPTION
 Check gml:id of document and make them unique if necessary