### PR TITLE
Fix org images when URL doesn't end with slash

### DIFF
--- a/spring/views/src/main/webapp/WEB-INF/views/index.jsp
+++ b/spring/views/src/main/webapp/WEB-INF/views/index.jsp
@@ -91,7 +91,7 @@
 
 <table style="background-color:white;width:100%;">
 	<tr>
-		<td align="center"><a target="_blank" href="http://52north.org"><img alt="52N" align="middle" width="286" src="static/images/52n-logo-220x80.png" /></a></td>
+		<td align="center"><a target="_blank" href="http://52north.org"><img alt="52N" align="middle" width="286" src="<c:url value="/static/images/52n-logo-220x80.png" />" /></a></td>
 	</tr>
 </table>
 
@@ -99,15 +99,15 @@
 
 <table style="background-color:white;width:100%;">
 	<tr>
-		<td align="center" style="width:25%;"><a target="_blank" href="http://www.uni-muenster.de/Geoinformatics/en/index.html"><img alt="IfGI"  align="middle" width="200" src="static/images/contribution/logo_ifgi.png"/></a></td>
-		<td align="center" style="width:25%;"><a target="_blank" href="http://www.axiomdatascience.com"><img alt="Axiom Data Science"  align="middle" width="85" src="static/images/contribution/axiom.png" /></a></td>
-		<td align="center" style="width:25%;"><a target="_blank" href="http://geomati.co"><img alt="geomati.co"  align="middle" width="85" src="static/images/contribution/logo_geomatico_256.png" /></a></td>
-		<td align="center" style="width:25%;"><a target="_blank" href="http://www.itg.es/"><img alt="ITG"  align="middle" width="104" src="static/images/contribution/Logo_ITG_vectorizado.png" /></a></td>
+		<td align="center" style="width:25%;"><a target="_blank" href="http://www.uni-muenster.de/Geoinformatics/en/index.html"><img alt="IfGI"  align="middle" width="200" src="<c:url value="/static/images/contribution/logo_ifgi.png"/>"/></a></td>
+		<td align="center" style="width:25%;"><a target="_blank" href="http://www.axiomdatascience.com"><img alt="Axiom Data Science"  align="middle" width="85" src="<c:url value="/static/images/contribution/axiom.png"/>"/></a></td>
+		<td align="center" style="width:25%;"><a target="_blank" href="http://geomati.co"><img alt="geomati.co"  align="middle" width="85" src="<c:url value="/static/images/contribution/logo_geomatico_256.png"/>"/></a></td>
+		<td align="center" style="width:25%;"><a target="_blank" href="http://www.itg.es/"><img alt="ITG"  align="middle" width="104" src="<c:url value="/static/images/contribution/Logo_ITG_vectorizado.png"/>"/></a></td>
 	</tr>
 	<tr>
-		<td align="center" style="width:25%;"><a target="_blank" href="http://www.zgis.at"><img alt="ZIGS"  align="middle" width="128" src="static/images/contribution/UniSalzburgZGIS_1.jpg"/></a></td>
+		<td align="center" style="width:25%;"><a target="_blank" href="http://www.zgis.at"><img alt="ZIGS"  align="middle" width="128" src="<c:url value="/static/images/contribution/UniSalzburgZGIS_1.jpg"/>"/></a></td>
 		<td align="center" style="width:25%;"><a href="<c:url value="/get-involved" />">Your logo?!<br/>Get involved!</a></td>
-		<td align="center" style="width:25%;"><img alt="Placeholder" align="middle" width="85" src="static/images/contribution/placeholder.png" /></td>
+		<td align="center" style="width:25%;"><img alt="Placeholder" align="middle" width="85" src="<c:url value="/static/images/contribution/placeholder.png"/>"/></td>
 	</tr>
 </table>
 
@@ -119,55 +119,55 @@
 
 <table style="background-color:white;width:100%;">
 	<tr>
-		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.nexosproject.eu/"><img alt="NeXOS - Next generation, Cost-effective, Compact, Multifunctional Web Enabled Ocean Sensor Systems Empowering Marine, Maritime and Fisheries Management" align="middle" width="172" src="static/images/funding/logo_nexos.png" /></a></td>
+		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.nexosproject.eu/"><img alt="NeXOS - Next generation, Cost-effective, Compact, Multifunctional Web Enabled Ocean Sensor Systems Empowering Marine, Maritime and Fisheries Management" align="middle" width="172" src="<c:url value="/static/images/funding/logo_nexos.png"/>"/></a></td>
 		<td style="padding:3px;width:70%;">The development of this version of the 52&deg;North SOS was supported by the <a target="_blank" href="http://cordis.europa.eu/fp7/home_en.html">European FP7</a> research project <a target="_blank" href="http://www.nexosproject.eu/">NeXOS</a> (co-funded by the European Commission under the grant agreement n&deg;614102)</td>
 	</tr>
 	<tr>
-		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.eo2heaven.org/"><img alt="EO2HEAVEN - Earth Observation and ENVironmental Modeling for the Mitigation of HEAlth Risks" align="middle" width="172" src="static/images/funding/logo_eo2heaven_200px.png" /></a></td>
+		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.eo2heaven.org/"><img alt="EO2HEAVEN - Earth Observation and ENVironmental Modeling for the Mitigation of HEAlth Risks" align="middle" width="172" src="<c:url value="/static/images/funding/logo_eo2heaven_200px.png"/>"/></a></td>
 		<td style="padding:3px;width:70%;">The development of this version of the 52&deg;North SOS was supported by the <a target="_blank" href="http://cordis.europa.eu/fp7/home_en.html">European FP7</a> research project <a target="_blank" href="http://www.eo2heaven.org/">EO2HEAVEN</a> (co-funded by the European Commission under the grant agreement n&deg;244100)</td>
 	</tr>
 	<tr>
-		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.geowow.eu/"><img alt="GEOWOW - GEOSS interoperability for Weather, Ocean and Water" align="middle" width="172" src="static/images/funding/logo_geowow.png" /></a></td>
+		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.geowow.eu/"><img alt="GEOWOW - GEOSS interoperability for Weather, Ocean and Water" align="middle" width="172" src="<c:url value="/static/images/funding/logo_geowow.png"/>"/></a></td>
 		<td style="padding:3px;width:70%;">The development of this version of the 52&deg;North SOS was supported by the <a target="_blank" href="http://cordis.europa.eu/fp7/home_en.html">European FP7</a> research project <a href="http://www.geowow.eu/" title="GEOWOW">GEOWOW</a> (co-funded by the European Commission under the grant agreement n&deg;282915)</td>
 	</tr>
 	<tr>
-		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.geoviqua.org/"><img alt="GeoViQua - QUAlity aware VIsualization for the Global Earth Observation System of Systems" align="middle" width="172" src="static/images/funding/logo_geoviqua.png" /></a></td>
+		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.geoviqua.org/"><img alt="GeoViQua - QUAlity aware VIsualization for the Global Earth Observation System of Systems" align="middle" width="172" src="<c:url value="/static/images/funding/logo_geoviqua.png"/>"/></a></td>
 		<td style="padding:3px;width:70%;">The development of this version of the 52&deg;North SOS was supported by the <a target="_blank" href="http://cordis.europa.eu/fp7/home_en.html">European FP7</a> research project <a href="http://www.geoviqua.org/" title="GeoViQua">GeoViQua</a> (co-funded by the European Commission under the grant agreement n&deg;265178)</td>
 	</tr>
 	<tr>
 		<td align="center" style="padding:3px;width:30%;">
 				<a target="_blank" href="http://inspire.ec.europa.eu"><img alt="INSPIRE" align="middle" width="60" src="static/images/funding/inspire-logo.jpg" /></a>
 				<a target="_blank" href="http://ec.europa.eu/isa/"><img alt="ISA" align="middle" width="60" src="static/images/funding/ISALogo.png" /></a>
-				<a target="_blank" href="http://ec.europa.eu/isa/actions/01-trusted-information-exchange/1-17action_en.htm"><img alt="ARE3NA" align="middle" width="60" src="static/images/funding/ARe3NA.png" /></a>
+				<a target="_blank" href="http://ec.europa.eu/isa/actions/01-trusted-information-exchange/1-17action_en.htm"><img alt="ARE3NA" align="middle" width="60" src="<c:url value="/static/images/funding/ARe3NA.png"/>"/></a>
 		</td>
 		<td style="padding:3px;width:70%;">The enhancements to make the 52&deg;North SOS an <a target="_blank" href="http://inspire.ec.europa.eu/">INSPIRE</a> compliant Download Service were funded by the <a target="_blank" href="http://ec.europa.eu/dgs/jrc/">JRC</a> under the <a target="_blank" href="http://ec.europa.eu/isa/">ISA</a> Programme's Action 1.17: A Reusable INSPIRE Reference Platform (<a target="_blank" href="http://ec.europa.eu/isa/actions/01-trusted-information-exchange/1-17action_en.htm">ARE3NA</a>).</td>
 	</tr>
 	<tr>
-		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.ioos.noaa.gov"><img alt="IOOS - Integrated Ocean Observing System" align="middle" width="156" src="static/images/funding/logo_ioos.png" /></a></td>
+		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.ioos.noaa.gov"><img alt="IOOS - Integrated Ocean Observing System" align="middle" width="156" src="<c:url value="/static/images/funding/logo_ioos.png"/>"/></a></td>
 		<td style="padding:3px;width:70%;">The <a target="_blank" href="http://www.ioos.noaa.gov">IOOS</a> project with the mission: <br/>Lead the integration of ocean, coastal, and Great Lakes observing capabilities, in collaboration with Federal and non-Federal partners, to maximize access to data and generation of information products, inform decision making, and promote economic, environmental, and social benefits to our Nation and the world. </td>
 	</tr>
 	<tr>
-		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.wupperverband.de"><img alt="Wupperverband" align="middle" width="196" src="static/images/funding/logo_wv.jpg" /></a></td>
+		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.wupperverband.de"><img alt="Wupperverband" align="middle" width="196" src="<c:url value="/static/images/funding/logo_wv.jpg"/>"/></a></td>
 		<td style="padding:3px;width:70%;">The <a target="_blank" href="http://www.wupperverband.de/">Wupperverband</a> for water, humans and the environment (Germany)</td>
 	</tr>
 	<tr>
-		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.irceline.be/en"><img alt="Belgian Interregional Environment Agency (IRCEL - CELINE)" align="middle" width="130" src="static/images/funding/logo_irceline_no_text.png" /></a></td>
+		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.irceline.be/en"><img alt="Belgian Interregional Environment Agency (IRCEL - CELINE)" align="middle" width="130" src="<c:url value="/static/images/funding/logo_irceline_no_text.png"/>"/></a></td>
 		<td style="padding:3px;width:70%;">The <a href="http://www.irceline.be/en" target="_blank" title="Belgian Interregional Environment Agency (IRCEL - CELINE)">Belgian Interregional Environment Agency (IRCEL - CELINE)</a> is primarily active with the domain of air quality (modelling, forecasts, informing the public on the state of their air quality, e-reporting to the EU under the air quality directives, participating in scientific research on air quality, etc.). IRCEL – CELINE is a permanent cooperation between three regional environment agencies: <a href="http://www.awac.be/" title="Agence wallonne de l&#39Air et du Climat (AWAC)">Agence wallonne de l&#39Air et du Climat (AWAC)</a>, <a href="http://www.ibgebim.be/" title="Bruxelles Environnement - Leefmilieu Brussel">Bruxelles Environnement - Leefmilieu Brussel</a> and <a href="http://www.vmm.be/" title="Vlaamse Milieumaatschappij (VMM)">Vlaamse Milieumaatschappij (VMM)</a>.</td>
 	</tr>
 	<tr>
-		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.ivl.se/english"><img alt="IVL Swedish Environmental Research Institute" align="middle" width="196" src="static/images/funding/ivl_eng_rgb_70mm.png" /></a></td>
+		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.ivl.se/english"><img alt="IVL Swedish Environmental Research Institute" align="middle" width="196" src="<c:url value="/static/images/funding/ivl_eng_rgb_70mm.png"/>"/></a></td>
 		<td style="padding:3px;width:70%;">The <a target="_blank" href="http://www.ivl.se/english">IVL Swedish Environmental Research Institute</a> is an independent, non-profit research institute, owned by a foundation jointly established by the Swedish Government and Swedish industry.</td>
 	</tr>
 	<tr>
-		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.dlr.de"><img alt="German Aerospace Centre" align="middle" width="172" src="static/images/funding/DLR-logo.jpg" /></a></td>
+		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.dlr.de"><img alt="German Aerospace Centre" align="middle" width="172" src="<c:url value="/static/images/funding/DLR-logo.jpg"/>"/></a></td>
 		<td style="padding:3px;width:70%;">The <a target="_blank" href="http://www.dlr.de">German Aerospace Centre</a> (Deutsches Zentrum fuer Luft- und Raumfahrt, DLR) and part of their <a target="_blank" href="http://www.dlr.de/eoc/en/desktopdefault.aspx/tabid-5400/10196_read-21914/">Environmental and Crisis Information System</a> (Umwelt- und Kriseninformationssystem, UKis)</td>
 	</tr>
 	<tr>
-		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.smart-project.info"><img alt="SMART Aquifer Characterisation Programme (SAC)" align="middle"  width="96" src="static/images/funding/Logo_SMART_v2_rescale.png" /></a></td>
+		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.smart-project.info"><img alt="SMART Aquifer Characterisation Programme (SAC)" align="middle"  width="96" src="<c:url value="/static/images/funding/Logo_SMART_v2_rescale.png"/>"/></a></td>
 		<td style="padding:3px;width:70%;">The <a target="_blank" href="http://www.smart-project.info">SMART</a> Project, funded by the <a target="_blank" href="http://www.msi.govt.nz/">Ministry of Business, Innovation and Employment</a> (07/2011 &ndash; 06/2017): <br/> Experts in the Smart Project will develop, apply, and validate pioneering new techniques for understanding New Zealand&lsquo;s groundwater resources. Satellite and airborne remote sensing techniques and Sensor Observation Services including seismic signals from earthquakes are used for rapid and costeffective characterisation and mapping of New Zealand&lsquo;s aquifer systems. Together with a stakeholder network the research team will use new methods to overcome the current time- and resourceconsuming challenges of in-time data acquisition. Special spatial skills in hydrogeology, geology, satellite remote sensing, geophysics, seismology, uncertainty mathematics and spatial information technology will be developed to assist with improvement of New Zealand&lsquo;s freshwater management.</td>
 	</tr>
 	<tr>
-		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.dlz-it.de/cln_008/DE/Home/home_node.html"><img alt="DLZ-IT" align="middle" width="140" src="static/images/funding/dlz-it-logo.jpg" /></a></td>
+		<td align="center" style="padding:3px;width:30%;"><a target="_blank" href="http://www.dlz-it.de/cln_008/DE/Home/home_node.html"><img alt="DLZ-IT" align="middle" width="140" src="<c:url value="/static/images/funding/dlz-it-logo.jpg"/>"/></a></td>
 		<td style="padding:3px;width:70%;">The <a target="_blank" href="http://www.dlz-it.de/">DLZ-IT</a> BMVBS Information Technology Services Centre of Federal Ministry of Transport, Building and Urban Development (Germany)</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
Currently the images on the front page don't load properly if the URL doesn't include a slash after the application context path.

Example of images not loading:
http://ioossos.axiomalaska.com/52n-sos-upstream

Images load with a trailing slash:
http://ioossos.axiomalaska.com/52n-sos-upstream/

Using `c:url` on the image URLs fixes this issue.
