### PR TITLE
Fix #389 build fails

### DIFF
--- a/coding/sos-v20/src/test/java/org/n52/sos/encode/OmEncoderv20Test.java
+++ b/coding/sos-v20/src/test/java/org/n52/sos/encode/OmEncoderv20Test.java
@@ -29,8 +29,6 @@
 package org.n52.sos.encode;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasXPath;
-import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -50,7 +48,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 import org.w3c.dom.Node;
-
 import org.n52.sos.ogc.gml.CodeWithAuthority;
 import org.n52.sos.ogc.gml.GmlConstants;
 import org.n52.sos.ogc.gml.time.TimeInstant;
@@ -112,7 +109,7 @@ public class OmEncoderv20Test {
 
     @Rule
     public final ErrorCollector errors = new ErrorCollector();
-
+    
     @Test
     public void testComplexObservation()
             throws OwsExceptionReport {

--- a/coding/sos-v20/src/test/java/org/n52/sos/encode/sos/v2/GetCapabilitiesResponseEncoderTest.java
+++ b/coding/sos-v20/src/test/java/org/n52/sos/encode/sos/v2/GetCapabilitiesResponseEncoderTest.java
@@ -44,54 +44,51 @@ import org.n52.sos.ogc.ows.OwsExceptionReport;
 import org.n52.sos.response.GetCapabilitiesResponse;
 import org.xml.sax.SAXException;
 
-
 public class GetCapabilitiesResponseEncoderTest {
 
-	private GetCapabilitiesResponseEncoder encoder;
-	
-	@Before
-	public void setUp(){
-		encoder = new GetCapabilitiesResponseEncoder();
-	}
+    private GetCapabilitiesResponseEncoder encoder;
 
-	@Test public void
-	should_create_static_capabilities()
-			throws OwsExceptionReport, SAXException, IOException {
-		XmlObject encodedResponse = encoder.encode(minimalCapabilities());
-		
-		Diff d = new Diff (encodedResponse.xmlText(), minimalCapabilities().getXmlString());
-		
-		assertThat(d.identical(), is(true));
-		assertThat(d.similar(), is(true));
-	}
-	
-	@Rule
-	public ExpectedException expectedEx = ExpectedException.none();
+    @Before
+    public void setUp() {
+        encoder = new GetCapabilitiesResponseEncoder();
+    }
 
-	@Test public void
-	should_throw_Exception_when_static_content_is_invalid()
-		throws OwsExceptionReport {
-		expectedEx.expect(XmlDecodingException.class);
-		expectedEx.expectMessage("Error while decoding Static Capabilities:\nBAD XML STRING");
-		
-		encoder.encode(badCapabilities());
-	}
-	
-	private GetCapabilitiesResponse minimalCapabilities() {
-		GetCapabilitiesResponse response = new GetCapabilitiesResponse();
-		response.setService("SOS");
-		response.setVersion("2.0.0");
-		response.setXmlString("<sos:Capabilities version=\"2.0.0\" xmlns:sos=\"http://www.opengis.net/sos/2.0\" " + 
-				"xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " + 
-				"xsi:schemaLocation=\"http://www.opengis.net/sos/2.0 http://schemas.opengis.net/sos/2.0/sosGetCapabilities.xsd\"/>");
-		return response;
-	}
-	
-	private GetCapabilitiesResponse badCapabilities() {
-		GetCapabilitiesResponse response = new GetCapabilitiesResponse();
-		response.setService("SOS");
-		response.setVersion("2.0.0");
-		response.setXmlString("BAD XML STRING");
-		return response;
-	}
+    @Test
+    public void should_create_static_capabilities() throws OwsExceptionReport, SAXException, IOException {
+        XmlObject encodedResponse = encoder.encode(minimalCapabilities());
+
+        Diff d = new Diff(encodedResponse.xmlText(), minimalCapabilities().getXmlString());
+
+        assertThat(d.identical(), is(true));
+        assertThat(d.similar(), is(true));
+    }
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Test
+    public void should_throw_Exception_when_static_content_is_invalid() throws OwsExceptionReport {
+        expectedEx.expect(XmlDecodingException.class);
+        expectedEx.expectMessage("Error while decoding Static Capabilities:\nBAD XML STRING");
+
+        encoder.encode(badCapabilities());
+    }
+
+    private GetCapabilitiesResponse minimalCapabilities() {
+        GetCapabilitiesResponse response = new GetCapabilitiesResponse();
+        response.setService("SOS");
+        response.setVersion("2.0.0");
+        response.setXmlString("<sos:Capabilities version=\"2.0.0\" xmlns:sos=\"http://www.opengis.net/sos/2.0\" "
+                + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+                + "xsi:schemaLocation=\"http://www.opengis.net/sos/2.0 http://schemas.opengis.net/sos/2.0/sosGetCapabilities.xsd\"/>");
+        return response;
+    }
+
+    private GetCapabilitiesResponse badCapabilities() {
+        GetCapabilitiesResponse response = new GetCapabilitiesResponse();
+        response.setService("SOS");
+        response.setVersion("2.0.0");
+        response.setXmlString("BAD XML STRING");
+        return response;
+    }
 }

--- a/core/api/src/main/java/org/n52/sos/encode/AbstractResponseEncoder.java
+++ b/core/api/src/main/java/org/n52/sos/encode/AbstractResponseEncoder.java
@@ -28,6 +28,8 @@
  */
 package org.n52.sos.encode;
 
+import static org.n52.sos.service.ServiceSettings.VALIDATE_RESPONSE;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collections;
@@ -42,13 +44,14 @@ import org.slf4j.LoggerFactory;
 
 import org.n52.sos.coding.CodingRepository;
 import org.n52.sos.coding.OperationKey;
+import org.n52.sos.config.annotation.Configurable;
+import org.n52.sos.config.annotation.Setting;
 import org.n52.sos.encode.streaming.StreamingEncoder;
 import org.n52.sos.exception.ows.NoApplicableCodeException;
 import org.n52.sos.exception.ows.concrete.UnsupportedEncoderInputException;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
 import org.n52.sos.ogc.sos.SosConstants.HelperValues;
 import org.n52.sos.response.AbstractServiceResponse;
-import org.n52.sos.service.ServiceConfiguration;
 import org.n52.sos.util.N52XmlHelper;
 import org.n52.sos.util.XmlHelper;
 import org.n52.sos.util.XmlOptionsHelper;
@@ -68,6 +71,7 @@ import com.google.common.collect.Sets;
  *
  * @since 4.0.0
  */
+@Configurable
 public abstract class AbstractResponseEncoder<T extends AbstractServiceResponse> extends AbstractXmlEncoder<T>
         implements StreamingEncoder<XmlObject, T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractResponseEncoder.class);
@@ -83,6 +87,8 @@ public abstract class AbstractResponseEncoder<T extends AbstractServiceResponse>
     private final Class<T> responseType;
 
     private final boolean validationEnabled;
+    
+    private boolean validateResponse = false;
 
     /**
      * constructor
@@ -171,7 +177,7 @@ public abstract class AbstractResponseEncoder<T extends AbstractServiceResponse>
                 LOGGER.debug("Encoded object {} is valid: {}", xml.schemaType().toString(),
                         XmlHelper.validateDocument(xml));
             } else {
-                if (ServiceConfiguration.getInstance().isValidateResponse()) {
+                if (validateResponse) {
                     LOGGER.warn("Encoded object {} is valid: {}", xml.schemaType().toString(),
                             XmlHelper.validateDocument(xml));
                 }
@@ -196,6 +202,11 @@ public abstract class AbstractResponseEncoder<T extends AbstractServiceResponse>
     @Override
     public boolean forceStreaming() {
     	return false;
+    }
+    
+    @Setting(VALIDATE_RESPONSE)
+    public void setValidateResponse(final boolean validateResponse) {
+        this.validateResponse = validateResponse;
     }
 
     private void setSchemaLocations(XmlObject document) {

--- a/core/api/src/main/java/org/n52/sos/service/ServiceConfiguration.java
+++ b/core/api/src/main/java/org/n52/sos/service/ServiceConfiguration.java
@@ -294,10 +294,15 @@ public class ServiceConfiguration {
         this.strictSpatialFilteringProfile = strictSpatialFilteringProfile;
     }
 
+    @Deprecated
     public boolean isValidateResponse() {
         return validateResponse;
     }
 
+    /**
+     * @deprecated Set directly in the class where this setting should be used.
+     */
+    @Deprecated
     @Setting(VALIDATE_RESPONSE)
     public void setValidateResponse(final boolean validateResponse) {
         this.validateResponse = validateResponse;

--- a/core/sqlite-config/src/main/java/org/n52/sos/config/sqlite/SQLiteSessionFactory.java
+++ b/core/sqlite-config/src/main/java/org/n52/sos/config/sqlite/SQLiteSessionFactory.java
@@ -39,10 +39,6 @@ import org.hibernate.SessionFactory;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.service.ServiceRegistry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import org.n52.sos.config.settings.ChoiceSettingDefinition;
 import org.n52.sos.config.sqlite.entities.AdminUser;
 import org.n52.sos.config.sqlite.entities.Binding;
 import org.n52.sos.config.sqlite.entities.BooleanSettingValue;
@@ -67,6 +63,8 @@ import org.n52.sos.ds.hibernate.AbstractSessionFactoryProvider;
 import org.n52.sos.exception.ConfigurationException;
 import org.n52.sos.ogc.gml.time.TimeInstant;
 import org.n52.sos.service.SosContextListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Christian Autermann <c.autermann@52north.org>

--- a/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/InsertSensorDAO.java
+++ b/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/InsertSensorDAO.java
@@ -58,6 +58,9 @@ import org.n52.sos.ds.hibernate.entities.Procedure;
 import org.n52.sos.ds.hibernate.entities.ProcedureDescriptionFormat;
 import org.n52.sos.ds.hibernate.entities.RelatedFeature;
 import org.n52.sos.ds.hibernate.entities.RelatedFeatureRole;
+import org.n52.sos.ds.hibernate.entities.TProcedure;
+import org.n52.sos.ds.hibernate.util.HibernateHelper;
+import org.n52.sos.exception.CodedException;
 import org.n52.sos.exception.ows.InvalidParameterValueException;
 import org.n52.sos.exception.ows.NoApplicableCodeException;
 import org.n52.sos.ogc.om.OmObservableProperty;
@@ -99,6 +102,7 @@ public class InsertSensorDAO extends AbstractInsertSensorDAO implements Capabili
 
     @Override
     public synchronized InsertSensorResponse insertSensor(final InsertSensorRequest request) throws OwsExceptionReport {
+        checkForTransactionalEntity();
         final InsertSensorResponse response = new InsertSensorResponse();
         response.setService(request.getService());
         response.setVersion(request.getVersion());
@@ -170,59 +174,6 @@ public class InsertSensorDAO extends AbstractInsertSensorDAO implements Capabili
             } else {
                 throw new InvalidParameterValueException(Sos2Constants.InsertSensorParams.procedureDescriptionFormat, request.getProcedureDescriptionFormat());
             }
-            
-//            final List<ObservationType> observationTypes =
-//                    new ObservationTypeDAO().getOrInsertObservationTypes(request.getMetadata().getObservationTypes(),
-//                            session);
-//            final List<FeatureOfInterestType> featureOfInterestTypes =
-//                    new FeatureOfInterestTypeDAO().getOrInsertFeatureOfInterestTypes(request.getMetadata()
-//                            .getFeatureOfInterestTypes(), session);
-//            if (procedureDescriptionFormat != null && observationTypes != null && featureOfInterestTypes != null) {
-//                final Procedure hProcedure =
-//                        new ProcedureDAO().getOrInsertProcedure(assignedProcedureID, procedureDescriptionFormat,
-//                                request.getProcedureDescription(), session);
-//                // TODO: set correct validTime,
-//                new ValidProcedureTimeDAO().insertValidProcedureTime(
-//                        hProcedure,
-//                        procedureDescriptionFormat,
-//                        getSensorDescriptionFromProcedureDescription(request.getProcedureDescription(),
-//                                assignedProcedureID), new DateTime(DateTimeZone.UTC), session);
-//                final List<ObservableProperty> hObservableProperties =
-//                        getOrInsertNewObservableProperties(request.getObservableProperty(), session);
-//                final ObservationConstellationDAO observationConstellationDAO = new ObservationConstellationDAO();
-//                final OfferingDAO offeringDAO = new OfferingDAO();
-//                for (final SosOffering assignedOffering : request.getAssignedOfferings()) {
-//                    final List<RelatedFeature> hRelatedFeatures = new LinkedList<RelatedFeature>();
-//                    if (request.getRelatedFeatures() != null && !request.getRelatedFeatures().isEmpty()) {
-//                        final RelatedFeatureDAO relatedFeatureDAO = new RelatedFeatureDAO();
-//                        final RelatedFeatureRoleDAO relatedFeatureRoleDAO = new RelatedFeatureRoleDAO();
-//                        for (final SwesFeatureRelationship relatedFeature : request.getRelatedFeatures()) {
-//                            final List<RelatedFeatureRole> relatedFeatureRoles =
-//                                    relatedFeatureRoleDAO.getOrInsertRelatedFeatureRole(relatedFeature.getRole(),
-//                                            session);
-//                            hRelatedFeatures.addAll(relatedFeatureDAO.getOrInsertRelatedFeature(
-//                                    relatedFeature.getFeature(), relatedFeatureRoles, session));
-//                        }
-//                    }
-//                    final Offering hOffering =
-//                            offeringDAO.getAndUpdateOrInsertNewOffering(assignedOffering.getIdentifier(),
-//                                    assignedOffering.getOfferingName(), hRelatedFeatures, observationTypes,
-//                                    featureOfInterestTypes, session);
-//                    for (final ObservableProperty hObservableProperty : hObservableProperties) {
-//                        observationConstellationDAO.checkOrInsertObservationConstellation(hProcedure,
-//                                hObservableProperty, hOffering, assignedOffering.isParentOffering(), session);
-//                    }
-//                }
-//                // TODO: parent and child procedures
-//                response.setAssignedProcedure(assignedProcedureID);
-//                response.setAssignedOffering(firstAssignedOffering.getIdentifier());
-//            } else if (procedureDescriptionFormat == null && observationTypes != null
-//                    && featureOfInterestTypes != null) {
-//                throw new InvalidParameterValueException(Sos2Constants.InsertSensorParams.procedureDescriptionFormat,
-//                        "");
-//            } else {
-//                throw new NoApplicableCodeException().withMessage("Error while inserting InsertSensor into database!");
-//            }
             session.flush();
             transaction.commit();
         } catch (final HibernateException he) {
@@ -284,6 +235,12 @@ public class InsertSensorDAO extends AbstractInsertSensorDAO implements Capabili
         // if procedureDescription not SensorML
         else {
             return procedureDescription.getSensorDescriptionXmlString();
+        }
+    }
+
+    private void checkForTransactionalEntity() throws CodedException {
+        if (!HibernateHelper.isEntitySupported(TProcedure.class)) {
+            throw new NoApplicableCodeException().withMessage("The transactional database profile is not activated!");
         }
     }
 


### PR DESCRIPTION
Fix #389
Set setting directly in the class where it is used and do not the setting in the `ServiceConfiguration` class.
Also adds a check for the transactional entity which is used in `InsertSensorDAO` to throw a 
meaningful exception.