### PR TITLE
Improve SOS 1.0 error message for too many GetObs offerings

### DIFF
--- a/operations/core-v100/src/main/java/org/n52/sos/request/operator/SosGetObservationOperatorV100.java
+++ b/operations/core-v100/src/main/java/org/n52/sos/request/operator/SosGetObservationOperatorV100.java
@@ -60,6 +60,7 @@ import org.n52.sos.service.Configurator;
 import org.n52.sos.util.CodingHelper;
 import org.n52.sos.util.OMHelper;
 import org.n52.sos.util.SosHelper;
+import org.opengis.parameter.InvalidParameterCardinalityException;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -227,8 +228,13 @@ public class SosGetObservationOperatorV100 extends
             Map<String, String> ncOfferings = SosHelper.getNcNameResolvedOfferings(offerings);
             CompositeOwsException exceptions = new CompositeOwsException();
 
-            if (offeringIds.size() != 1) {
+            //SOS 1.0 GetObservation requires exactly one offering
+            if (offeringIds.isEmpty()) {
                 throw new MissingOfferingParameterException();
+            } else if (offeringIds.size() > 1) {
+                throw new InvalidParameterCardinalityException(
+                        "Exactly one offering is required",
+                        SosConstants.GetObservationParams.offering.name());
             }
 
             for (String offeringId : offeringIds) {


### PR DESCRIPTION
Currently a missing parameter exception is thrown if >1 offerings are provided in an SOS 1.0.0 GetObs request.