### PR TITLE
Fixes #416 - Test Client - wrong type of the wml2:metadata element

### DIFF
--- a/coding/wml-v20/src/main/java/org/n52/sos/encode/streaming/WmlTVPEncoderv20XmlStreamWriter.java
+++ b/coding/wml-v20/src/main/java/org/n52/sos/encode/streaming/WmlTVPEncoderv20XmlStreamWriter.java
@@ -148,13 +148,13 @@ public class WmlTVPEncoderv20XmlStreamWriter extends AbstractOmV20XmlStreamWrite
     private void writeMeasurementTimeseriesMetadata(String id) throws XMLStreamException {
         start(WaterMLConstants.QN_METADATA);
         writeNewLine();
-        start(WaterMLConstants.QN_TIMESERIES_METADATA);
+        start(WaterMLConstants.QN_MEASUREMENT_TIMESERIES_METADATA);
         writeNewLine();
         empty(WaterMLConstants.QN_TEMPORAL_EXTENT);
         addXlinkHrefAttr("#" + id);
         writeNewLine();
         indent--;
-        end(WaterMLConstants.QN_TIMESERIES_METADATA);
+        end(WaterMLConstants.QN_MEASUREMENT_TIMESERIES_METADATA);
         writeNewLine();
         end(WaterMLConstants.QN_METADATA);
         indent++;

--- a/coding/wml-v20/src/main/java/org/n52/sos/ogc/wml/WaterMLConstants.java
+++ b/coding/wml-v20/src/main/java/org/n52/sos/ogc/wml/WaterMLConstants.java
@@ -106,6 +106,8 @@ public interface WaterMLConstants {
     
     String EN_TIMESERIES_METADATA = "TimeseriesMetadata";
     
+    String EN_MEASUREMENT_TIMESERIES_METADATA = "MeasurementTimeseriesMetadata";
+    
     String EN_TEMPORAL_EXTENT = "temporalExtent";
     
     String EN_DEFAULT_POINT_METADATA = "defaultPointMetadata";
@@ -133,6 +135,8 @@ public interface WaterMLConstants {
     QName QN_MEASUREMENT_TIMESERIES = new QName(NS_WML_20, EN_MEASUREMENT_TIMESERIES, NS_WML_20_PREFIX);
 
     QName QN_TIMESERIES_METADATA = new QName(NS_WML_20, EN_TIMESERIES_METADATA, NS_WML_20_PREFIX);
+    
+    QName QN_MEASUREMENT_TIMESERIES_METADATA = new QName(NS_WML_20, EN_MEASUREMENT_TIMESERIES_METADATA, NS_WML_20_PREFIX);
 
     QName QN_TEMPORAL_EXTENT = new QName(NS_WML_20, EN_TEMPORAL_EXTENT, NS_WML_20_PREFIX);
 


### PR DESCRIPTION
Change TimeseriesMetadat for MeasurmentTimeseries to MeasurementTimeseriesMetadata as defined in the OGC WaterML 2.0 specification.