### PR TITLE
Support for generic XML parameters

### DIFF
--- a/coding/json/src/main/java/org/n52/sos/decode/json/impl/ObservationDecoder.java
+++ b/coding/json/src/main/java/org/n52/sos/decode/json/impl/ObservationDecoder.java
@@ -74,9 +74,9 @@ import com.vividsolutions.jts.geom.Geometry;
 
 /**
  * TODO JavaDoc
- * 
+ *
  * @author Christian Autermann <c.autermann@52north.org>
- * 
+ *
  * @since 4.0.0
  */
 public class ObservationDecoder extends JSONDecoder<OmObservation> {
@@ -187,35 +187,35 @@ public class ObservationDecoder extends JSONDecoder<OmObservation> {
 
     private NamedValue<?> parseNamedValueValue(JsonNode value) throws OwsExceptionReport {
         if (value.isTextual()) {
-            NamedValue<W3CHrefAttribute> nv = new NamedValue<W3CHrefAttribute>();
+            NamedValue<W3CHrefAttribute> nv = new NamedValue<>();
             nv.setValue(new HrefAttributeValue(new W3CHrefAttribute(value.asText())));
             return nv;
         } else if (value.isBoolean()) {
-            NamedValue<Boolean> nv = new NamedValue<Boolean>();
+            NamedValue<Boolean> nv = new NamedValue<>();
             nv.setValue(new BooleanValue(value.asBoolean()));
             return nv;
         } else if (value.isInt()) {
-            NamedValue<Integer> nv = new NamedValue<Integer>();
+            NamedValue<Integer> nv = new NamedValue<>();
             nv.setValue(new CountValue(value.asInt()));
             return nv;
         } else if (value.isObject()) {
             if (value.has(JSONConstants.CODESPACE)) {
-                NamedValue<String> nv = new NamedValue<String>();
+                NamedValue<String> nv = new NamedValue<>();
                 nv.setValue(parseCategroyValue(value));
-                return nv;  
+                return nv;
             } else if (value.has(JSONConstants.UOM)) {
-                NamedValue<Double> nv = new NamedValue<Double>();
+                NamedValue<Double> nv = new NamedValue<>();
                 nv.setValue(parseQuantityValue(value));
-                return nv; 
+                return nv;
             } else if (value.has(JSONConstants.COORDINATES)) {
-                NamedValue<Geometry> nv = new NamedValue<Geometry>();
+                NamedValue<Geometry> nv = new NamedValue<>();
                 nv.setValue(new GeometryValue(geometryDecoder.decodeJSON(value, false)));
                 return nv;
             }
         }
         throw new NotYetSupportedException(value.toString());
     }
-	
+
     protected AbstractFeature parseFeatureOfInterest(JsonNode node) throws OwsExceptionReport {
         return featureDecoder.decodeJSON(node.path(JSONConstants.FEATURE_OF_INTEREST), false);
     }
@@ -245,7 +245,7 @@ public class ObservationDecoder extends JSONDecoder<OmObservation> {
 //                        .path(JSONConstants.RESULT).path(JSONConstants.UOM).textValue());
         return new SingleObservationValue<Double>(parsePhenomenonTime(node), qv);
     }
-    
+
     private QuantityValue parseQuantityValue(JsonNode node) throws OwsExceptionReport {
        return new QuantityValue(node.path(JSONConstants.VALUE).doubleValue(), node.path(JSONConstants.UOM).textValue());
     }
@@ -271,7 +271,7 @@ public class ObservationDecoder extends JSONDecoder<OmObservation> {
 //                        .path(JSONConstants.RESULT).path(JSONConstants.CODESPACE).textValue());
         return new SingleObservationValue<String>(parsePhenomenonTime(node), v);
     }
-    
+
     private CategoryValue parseCategroyValue(JsonNode node) throws OwsExceptionReport {
         return new CategoryValue(node.path(JSONConstants.VALUE).textValue(), node.path(JSONConstants.CODESPACE).textValue());
     }
@@ -280,5 +280,5 @@ public class ObservationDecoder extends JSONDecoder<OmObservation> {
         GeometryValue v = new GeometryValue(geometryDecoder.decodeJSON(node.path(JSONConstants.RESULT), false));
         return new SingleObservationValue<Geometry>(parsePhenomenonTime(node), v);
     }
-    
+
 }

--- a/coding/sos-v20/src/main/java/org/n52/sos/decode/AbstractOmDecoderv20.java
+++ b/coding/sos-v20/src/main/java/org/n52/sos/decode/AbstractOmDecoderv20.java
@@ -28,8 +28,13 @@
  */
 package org.n52.sos.decode;
 
+import java.math.BigInteger;
 import java.util.Set;
 
+import net.opengis.om.x20.NamedValuePropertyType;
+import net.opengis.om.x20.NamedValueType;
+
+import org.apache.xmlbeans.SchemaType;
 import org.apache.xmlbeans.XmlBoolean;
 import org.apache.xmlbeans.XmlDouble;
 import org.apache.xmlbeans.XmlException;
@@ -38,6 +43,10 @@ import org.apache.xmlbeans.XmlInteger;
 import org.apache.xmlbeans.XmlObject;
 import org.apache.xmlbeans.XmlString;
 import org.apache.xmlbeans.impl.values.XmlAnyTypeImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.n52.sos.exception.ows.concrete.NoDecoderForKeyException;
 import org.n52.sos.exception.ows.concrete.UnsupportedDecoderInputException;
 import org.n52.sos.ogc.gml.AbstractGeometry;
 import org.n52.sos.ogc.gml.GmlMeasureType;
@@ -51,6 +60,8 @@ import org.n52.sos.ogc.om.values.HrefAttributeValue;
 import org.n52.sos.ogc.om.values.QuantityValue;
 import org.n52.sos.ogc.om.values.ReferenceValue;
 import org.n52.sos.ogc.om.values.TextValue;
+import org.n52.sos.ogc.om.values.Value;
+import org.n52.sos.ogc.om.values.XmlValue;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
 import org.n52.sos.ogc.swe.simpleType.SweBoolean;
 import org.n52.sos.ogc.swe.simpleType.SweCategory;
@@ -59,19 +70,24 @@ import org.n52.sos.ogc.swe.simpleType.SweQuantity;
 import org.n52.sos.ogc.swe.simpleType.SweText;
 import org.n52.sos.util.CodingHelper;
 import org.n52.sos.w3c.xlink.W3CHrefAttribute;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
 import com.vividsolutions.jts.geom.Geometry;
 
-import net.opengis.om.x20.NamedValuePropertyType;
-import net.opengis.om.x20.NamedValueType;
-
 public abstract class AbstractOmDecoderv20 extends AbstractGmlDecoderv321<Object, Object> {
-	
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractOmDecoderv20.class);
-	
+    private static final SchemaType XML_STRING_SCHEMA_TYPE
+            = XmlString.Factory.newInstance().schemaType();
+    private static final SchemaType XML_BOOLEAN_SCHEMA_TYPE
+            = XmlBoolean.Factory.newInstance().schemaType();
+    private static final SchemaType XML_INT_SCHEMA_TYPE
+            = XmlInt.Factory.newInstance().schemaType();
+    private static final SchemaType XML_INTEGER_SCHEMA_TYPE
+            = XmlInteger.Factory.newInstance().schemaType();
+    private static final SchemaType XML_DOUBLE_SCHEMA_TYPE
+            = XmlDouble.Factory.newInstance().schemaType();
+
 	@Override
 	public Object decode(Object object) throws OwsExceptionReport, UnsupportedDecoderInputException {
 		if (object instanceof NamedValuePropertyType) {
@@ -81,7 +97,7 @@ public abstract class AbstractOmDecoderv20 extends AbstractGmlDecoderv321<Object
         }
         throw new UnsupportedDecoderInputException(this, object);
 	}
-	
+
 	protected Set<NamedValue<?>> parseNamedValueTypeArray(NamedValuePropertyType[] namedValuePropertyArray)
             throws OwsExceptionReport {
         Set<NamedValue<?>> parameters = Sets.newTreeSet();
@@ -99,7 +115,7 @@ public abstract class AbstractOmDecoderv20 extends AbstractGmlDecoderv321<Object
             sosNamedValue.setName(referenceType);
             return sosNamedValue;
         } else if (namedValueProperty.isSetHref()) {
-            NamedValue<ReferenceType> sosNamedValue = new NamedValue<ReferenceType>();
+            NamedValue<ReferenceType> sosNamedValue = new NamedValue<>();
             ReferenceType referenceType = new ReferenceType(namedValueProperty.getHref());
             if (namedValueProperty.isSetTitle()) {
                 referenceType.setTitle(namedValueProperty.getTitle());
@@ -111,6 +127,7 @@ public abstract class AbstractOmDecoderv20 extends AbstractGmlDecoderv321<Object
         }
     }
 
+
 	protected NamedValue<?> parseNamedValueValue(XmlObject xmlObject) throws OwsExceptionReport {
         if (xmlObject.schemaType() == XmlAnyTypeImpl.type) {
             try {
@@ -120,93 +137,67 @@ public abstract class AbstractOmDecoderv20 extends AbstractGmlDecoderv321<Object
             }
         }
         Object value = null;
-        if (XmlBoolean.Factory.newInstance().schemaType().equals(xmlObject.schemaType())) {
-            value = ((XmlBoolean) xmlObject).getBooleanValue();
-        } else if (XmlString.Factory.newInstance().schemaType().equals(xmlObject.schemaType())) {
-            value = ((XmlString) xmlObject).getStringValue();
-        } else if (XmlInt.Factory.newInstance().schemaType().equals(xmlObject.schemaType())) {
-            value = ((XmlInt) xmlObject).getIntValue();
-        } else if (XmlInteger.Factory.newInstance().schemaType().equals(xmlObject.schemaType())) {
-            value = ((XmlInteger) xmlObject).getBigIntegerValue().intValue();
-        } else if (XmlDouble.Factory.newInstance().schemaType().equals(xmlObject.schemaType())) {
-            value = ((XmlDouble) xmlObject).getDoubleValue();
+        if (XML_BOOLEAN_SCHEMA_TYPE.equals(xmlObject.schemaType())) {
+            value = new BooleanValue(((XmlBoolean) xmlObject).getBooleanValue());
+        } else if (XML_STRING_SCHEMA_TYPE.equals(xmlObject.schemaType())) {
+            value = new TextValue(((XmlString) xmlObject).getStringValue());
+        } else if (XML_INT_SCHEMA_TYPE.equals(xmlObject.schemaType())) {
+            value = new CountValue(((XmlInt) xmlObject).getIntValue());
+        } else if (XML_INTEGER_SCHEMA_TYPE.equals(xmlObject.schemaType())) {
+            // FIXME: why do we not support BigInteger?
+            BigInteger bigInteger = ((XmlInteger) xmlObject).getBigIntegerValue();
+            if (bigInteger.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) > 0 ||
+                bigInteger.compareTo(BigInteger.valueOf(Integer.MIN_VALUE)) < 0) {
+                throw new UnsupportedDecoderInputException(this, xmlObject);
+            }
+            value = new CountValue(bigInteger.intValue());
+        } else if (XML_DOUBLE_SCHEMA_TYPE.equals(xmlObject.schemaType())) {
+            value = new QuantityValue(((XmlDouble) xmlObject).getDoubleValue());
         } else {
-            value = CodingHelper.decodeXmlObject(xmlObject);
+            try {
+                value = CodingHelper.decodeXmlObject(xmlObject);
+            } catch (NoDecoderForKeyException e) {
+                value = new XmlValue(xmlObject);
+            }
         }
-        if (value instanceof BooleanValue) {
-            NamedValue<Boolean> namedValue = new NamedValue<Boolean>();
-            namedValue.setValue((BooleanValue) value);
+        if (value instanceof Value<?>) {
+            NamedValue<Object> namedValue = new NamedValue<>();
+            namedValue.setValue((Value<Object>) value);
             return namedValue;
         } else if (value instanceof SweBoolean) {
-            NamedValue<Boolean> namedValue = new NamedValue<Boolean>();
+            NamedValue<Boolean> namedValue = new NamedValue<>();
             namedValue.setValue(new BooleanValue(((SweBoolean) value).getValue()));
             return namedValue;
-        } else if (value instanceof Boolean) {
-            NamedValue<Boolean> namedValue = new NamedValue<Boolean>();
-            namedValue.setValue(new BooleanValue((Boolean) value));
-            return namedValue;
-        } else if (value instanceof CategoryValue) {
-            NamedValue<String> namedValue = new NamedValue<String>();
-            namedValue.setValue((CategoryValue) value);
-            return namedValue;
         } else if (value instanceof SweCategory) {
-            NamedValue<String> namedValue = new NamedValue<String>();
+            NamedValue<String> namedValue = new NamedValue<>();
             namedValue.setValue(new CategoryValue(((SweCategory) value).getValue(), ((SweCategory) value).getCodeSpace()));
             return namedValue;
-        } else if (value instanceof CountValue) {
-            NamedValue<Integer> namedValue = new NamedValue<Integer>();
-            namedValue.setValue((CountValue) value);
-            return namedValue;
         } else if (value instanceof SweCount) {
-            NamedValue<Integer> namedValue = new NamedValue<Integer>();
+            NamedValue<Integer> namedValue = new NamedValue<>();
             namedValue.setValue(new CountValue(((CountValue) value).getValue()));
             return namedValue;
-        } else if (value instanceof Integer) {
-            NamedValue<Integer> namedValue = new NamedValue<Integer>();
-            namedValue.setValue(new CountValue((Integer) value));
-            return namedValue;
-        } else if (value instanceof GeometryValue) {
-            NamedValue<Geometry> namedValue = new NamedValue<Geometry>();
-            namedValue.setValue((GeometryValue) value);
-            return namedValue;
-        } else if (value instanceof QuantityValue) {
-            NamedValue<Double> namedValue = new NamedValue<Double>();
-            namedValue.setValue((QuantityValue) value);
-            return namedValue;
         } else if (value instanceof GmlMeasureType) {
-            NamedValue<Double> namedValue = new NamedValue<Double>();
+            NamedValue<Double> namedValue = new NamedValue<>();
             namedValue.setValue(new QuantityValue(((GmlMeasureType) value).getValue(), ((GmlMeasureType) value).getUnit()));
             return namedValue;
         } else if (value instanceof SweQuantity) {
-            NamedValue<Double> namedValue = new NamedValue<Double>();
+            NamedValue<Double> namedValue = new NamedValue<>();
             namedValue.setValue(new QuantityValue(((SweQuantity) value).getValue(), ((SweQuantity) value).getUom()));
             return namedValue;
-        } else if (value instanceof Double) {
-            NamedValue<Double> namedValue = new NamedValue<Double>();
-            namedValue.setValue(new QuantityValue((Double) value));
-            return namedValue;
-        } else if (value instanceof TextValue) {
-            NamedValue<String> namedValue = new NamedValue<String>();
-            namedValue.setValue((TextValue) value);
-            return namedValue;
         } else if (value instanceof SweText) {
-            NamedValue<String> namedValue = new NamedValue<String>();
+            NamedValue<String> namedValue = new NamedValue<>();
             namedValue.setValue(new TextValue(((SweText) value).getValue()));
             return namedValue;
-        } else if (value instanceof String) {
-            NamedValue<String> namedValue = new NamedValue<String>();
-            namedValue.setValue(new TextValue((String) value));
-            return namedValue;
         } else if (value instanceof AbstractGeometry) {
-            NamedValue<Geometry> namedValue = new NamedValue<Geometry>();
+            NamedValue<Geometry> namedValue = new NamedValue<>();
             namedValue.setValue(new GeometryValue((AbstractGeometry)value));
             return namedValue;
         } else if (value instanceof ReferenceType) {
-            NamedValue<ReferenceType> namedValue = new NamedValue<ReferenceType>();
+            NamedValue<ReferenceType> namedValue = new NamedValue<>();
             namedValue.setValue(new ReferenceValue((ReferenceType)value));
             return namedValue;
         } else if (value instanceof W3CHrefAttribute) {
-            NamedValue<W3CHrefAttribute> namedValue = new NamedValue<W3CHrefAttribute>();
+            NamedValue<W3CHrefAttribute> namedValue = new NamedValue<>();
             namedValue.setValue(new HrefAttributeValue((W3CHrefAttribute)value));
             return namedValue;
         } else {

--- a/coding/sos-v20/src/main/java/org/n52/sos/encode/AbstractOmEncoderv20.java
+++ b/coding/sos-v20/src/main/java/org/n52/sos/encode/AbstractOmEncoderv20.java
@@ -35,6 +35,13 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.Set;
 
+import net.opengis.om.x20.NamedValueType;
+import net.opengis.om.x20.OMObservationDocument;
+import net.opengis.om.x20.OMObservationPropertyType;
+import net.opengis.om.x20.OMObservationType;
+import net.opengis.om.x20.OMProcessPropertyType;
+import net.opengis.om.x20.TimeObjectPropertyType;
+
 import org.apache.xmlbeans.XmlBoolean;
 import org.apache.xmlbeans.XmlInteger;
 import org.apache.xmlbeans.XmlObject;
@@ -42,6 +49,9 @@ import org.apache.xmlbeans.XmlOptions;
 import org.apache.xmlbeans.XmlString;
 import org.isotc211.x2005.gmd.AbstractDQElementDocument;
 import org.isotc211.x2005.gmd.DQElementPropertyType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.n52.sos.convert.Converter;
 import org.n52.sos.convert.ConverterException;
 import org.n52.sos.convert.ConverterRepository;
@@ -76,6 +86,7 @@ import org.n52.sos.ogc.om.values.TVPValue;
 import org.n52.sos.ogc.om.values.TextValue;
 import org.n52.sos.ogc.om.values.UnknownValue;
 import org.n52.sos.ogc.om.values.Value;
+import org.n52.sos.ogc.om.values.XmlValue;
 import org.n52.sos.ogc.om.values.visitor.ValueVisitor;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
 import org.n52.sos.ogc.sos.SosConstants;
@@ -92,18 +103,9 @@ import org.n52.sos.util.StringHelper;
 import org.n52.sos.util.XmlHelper;
 import org.n52.sos.util.XmlOptionsHelper;
 import org.n52.sos.w3c.W3CConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-
-import net.opengis.om.x20.NamedValueType;
-import net.opengis.om.x20.OMObservationDocument;
-import net.opengis.om.x20.OMObservationPropertyType;
-import net.opengis.om.x20.OMObservationType;
-import net.opengis.om.x20.OMProcessPropertyType;
-import net.opengis.om.x20.TimeObjectPropertyType;
 
 
 public abstract class AbstractOmEncoderv20
@@ -580,7 +582,7 @@ public abstract class AbstractOmEncoderv20
         }
         return null;
     }
-    
+
     private void setResultQualities(OMObservationType xbObservation, OmObservation sosObservation)
             throws OwsExceptionReport {
         if (sosObservation.isSetResultQuality()) {
@@ -634,7 +636,7 @@ public abstract class AbstractOmEncoderv20
     protected static XmlObject encodeGML(Object o, Map<HelperValues, String> helperValues) throws OwsExceptionReport {
         return CodingHelper.encodeObjectToXml(GmlConstants.NS_GML_32, o, helperValues);
     }
-    
+
     protected static XmlObject encodeSweCommon(Object o) throws OwsExceptionReport {
         return CodingHelper.encodeObjectToXml(SweConstants.NS_SWE_20, o);
     }
@@ -729,6 +731,12 @@ public abstract class AbstractOmEncoderv20
             helperValues.put(HelperValues.PROPERTY_TYPE, null);
             helperValues.put(HelperValues.GMLID, JavaHelper.generateID(value.toString()));
             return helperValues;
+        }
+
+        @Override
+        public XmlObject visit(XmlValue value)
+                throws OwsExceptionReport {
+            return value.getValue();
         }
 
         private static XmlObject defaultValue(Value<?> value) {

--- a/coding/sos-v20/src/main/java/org/n52/sos/encode/OmEncoderv20.java
+++ b/coding/sos-v20/src/main/java/org/n52/sos/encode/OmEncoderv20.java
@@ -71,6 +71,7 @@ import org.n52.sos.ogc.om.values.SweDataArrayValue;
 import org.n52.sos.ogc.om.values.TVPValue;
 import org.n52.sos.ogc.om.values.TextValue;
 import org.n52.sos.ogc.om.values.UnknownValue;
+import org.n52.sos.ogc.om.values.XmlValue;
 import org.n52.sos.ogc.om.values.visitor.ValueVisitor;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
 import org.n52.sos.ogc.sensorML.SensorMLConstants;
@@ -99,7 +100,7 @@ public class OmEncoderv20 extends AbstractOmEncoderv20 {
      * file
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(OmEncoderv20.class);
-    
+
     private static final Set<EncoderKey> ENCODER_KEYS = CodingHelper.encoderKeysForElements(OmConstants.NS_OM_2,
             OmObservation.class, NamedValue.class, SingleObservationValue.class, MultiObservationValues.class);
 
@@ -440,6 +441,12 @@ public class OmEncoderv20 extends AbstractOmEncoderv20 {
 
         @Override
         public XmlObject visit(UnknownValue value)
+                throws OwsExceptionReport {
+            return null;
+        }
+
+        @Override
+        public XmlObject visit(XmlValue value)
                 throws OwsExceptionReport {
             return null;
         }

--- a/core/api/src/main/java/org/n52/sos/ogc/om/values/XmlValue.java
+++ b/core/api/src/main/java/org/n52/sos/ogc/om/values/XmlValue.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2012-2016 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *     - Apache License, version 2.0
+ *     - Apache Software License, version 1.0
+ *     - GNU Lesser General Public License, version 3
+ *     - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *     - Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public
+ * License version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ */
+package org.n52.sos.ogc.om.values;
+
+import java.util.Objects;
+
+import org.apache.xmlbeans.XmlObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.n52.sos.ogc.om.values.visitor.ValueVisitor;
+import org.n52.sos.ogc.om.values.visitor.VoidValueVisitor;
+import org.n52.sos.ogc.ows.OwsExceptionReport;
+
+/**
+ * TODO JavaDoc
+ *
+ * @author Christian Autermann
+ */
+public class XmlValue implements Value<XmlObject> {
+
+    private static final Logger log = LoggerFactory.getLogger(XmlValue.class);
+    private static final long serialVersionUID = 5895818649831864521L;
+
+    private XmlObject xml;
+    private String unit;
+
+    public XmlValue(XmlObject xml) {
+        this.xml = xml;
+    }
+
+    @Override
+    public void setValue(XmlObject value) {
+        this.xml = value;
+    }
+
+    @Override
+    public XmlObject getValue() {
+        return this.xml;
+    }
+
+    @Override
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+
+    @Override
+    public String getUnit() {
+        return this.unit;
+    }
+
+    @Override
+    public boolean isSetValue() {
+        return this.xml != null;
+    }
+
+    @Override
+    public boolean isSetUnit() {
+        return this.unit != null && !this.unit.isEmpty();
+    }
+
+    @Override
+    public <X> X accept(ValueVisitor<X> visitor)
+            throws OwsExceptionReport {
+        return visitor.visit(this);
+    }
+
+    @Override
+    public void accept(VoidValueVisitor visitor)
+            throws OwsExceptionReport {
+        visitor.visit(this);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 41 * hash + Objects.hashCode(this.xml);
+        hash = 41 * hash + Objects.hashCode(this.unit);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final XmlValue other = (XmlValue) obj;
+        if (!Objects.equals(this.unit, other.unit)) {
+            return false;
+        }
+        if (!Objects.equals(this.xml, other.xml)) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/core/api/src/main/java/org/n52/sos/ogc/om/values/visitor/ValueVisitor.java
+++ b/core/api/src/main/java/org/n52/sos/ogc/om/values/visitor/ValueVisitor.java
@@ -41,6 +41,7 @@ import org.n52.sos.ogc.om.values.SweDataArrayValue;
 import org.n52.sos.ogc.om.values.TVPValue;
 import org.n52.sos.ogc.om.values.TextValue;
 import org.n52.sos.ogc.om.values.UnknownValue;
+import org.n52.sos.ogc.om.values.XmlValue;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
 
 /**
@@ -86,5 +87,8 @@ public interface ValueVisitor<T> {
             throws OwsExceptionReport;
 
     T visit(UnknownValue value)
+            throws OwsExceptionReport;
+
+    T visit(XmlValue value)
             throws OwsExceptionReport;
 }

--- a/core/api/src/main/java/org/n52/sos/ogc/om/values/visitor/VoidValueVisitor.java
+++ b/core/api/src/main/java/org/n52/sos/ogc/om/values/visitor/VoidValueVisitor.java
@@ -41,6 +41,7 @@ import org.n52.sos.ogc.om.values.SweDataArrayValue;
 import org.n52.sos.ogc.om.values.TVPValue;
 import org.n52.sos.ogc.om.values.TextValue;
 import org.n52.sos.ogc.om.values.UnknownValue;
+import org.n52.sos.ogc.om.values.XmlValue;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
 
 /**
@@ -140,6 +141,13 @@ public abstract class VoidValueVisitor implements ValueVisitor<Void> {
         return null;
     }
 
+    @Override
+    public Void visit(XmlValue value)
+            throws OwsExceptionReport {
+        _visit(value);
+        return null;
+    }
+
     protected abstract void _visit(BooleanValue value)
             throws OwsExceptionReport;
 
@@ -177,5 +185,8 @@ public abstract class VoidValueVisitor implements ValueVisitor<Void> {
             throws OwsExceptionReport;
 
     protected abstract void _visit(UnknownValue value)
+            throws OwsExceptionReport;
+
+    protected abstract void _visit(XmlValue value)
             throws OwsExceptionReport;
 }

--- a/core/api/src/main/java/org/n52/sos/util/OMHelper.java
+++ b/core/api/src/main/java/org/n52/sos/util/OMHelper.java
@@ -51,6 +51,7 @@ import org.n52.sos.ogc.om.values.TVPValue;
 import org.n52.sos.ogc.om.values.TextValue;
 import org.n52.sos.ogc.om.values.UnknownValue;
 import org.n52.sos.ogc.om.values.Value;
+import org.n52.sos.ogc.om.values.XmlValue;
 import org.n52.sos.ogc.om.values.visitor.ValueVisitor;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
 import org.n52.sos.ogc.swe.SweAbstractDataComponent;
@@ -242,6 +243,12 @@ public final class OMHelper {
 
         @Override
         public String visit(UnknownValue value) {
+            return defaultValue();
+        }
+
+        @Override
+        public String visit(XmlValue value)
+                throws OwsExceptionReport {
             return defaultValue();
         }
 

--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/entities/parameter/ParameterFactory.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/entities/parameter/ParameterFactory.java
@@ -43,6 +43,7 @@ import org.n52.sos.ogc.om.values.TVPValue;
 import org.n52.sos.ogc.om.values.TextValue;
 import org.n52.sos.ogc.om.values.UnknownValue;
 import org.n52.sos.ogc.om.values.Value;
+import org.n52.sos.ogc.om.values.XmlValue;
 import org.n52.sos.ogc.om.values.visitor.ValueVisitor;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
 
@@ -91,8 +92,16 @@ public class ParameterFactory implements ValueVisitor<ValuedParameter<?>> {
         return instantiate(textClass());
     }
 
+    public Class<? extends XmlValuedParameter> xmlClass() {
+        return XmlValuedParameter.class;
+    }
+
+    public XmlValuedParameter xml() throws OwsExceptionReport {
+        return instantiate(xmlClass());
+    }
+
     private <T extends ValuedParameter<?>> T instantiate(Class<T> c) throws OwsExceptionReport {
-    
+
         try {
             return c.newInstance();
         } catch (InstantiationException | IllegalAccessException ex) {
@@ -165,7 +174,13 @@ public class ParameterFactory implements ValueVisitor<ValuedParameter<?>> {
     public ValuedParameter<?> visit(UnknownValue value) throws OwsExceptionReport {
         throw notSupported(value);
     }
-    
+
+    @Override
+    public ValuedParameter<?> visit(XmlValue value)
+            throws OwsExceptionReport {
+        return xml();
+    }
+
     private OwsExceptionReport notSupported(Value<?> value)
             throws OwsExceptionReport {
         throw new NoApplicableCodeException()

--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/entities/parameter/ParameterVisitor.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/entities/parameter/ParameterVisitor.java
@@ -36,7 +36,6 @@ public interface ParameterVisitor<T> {
     NamedValue<T> visit(QuantityValuedParameter o)
             throws OwsExceptionReport;
 
-
     NamedValue<T> visit(BooleanValuedParameter o)
             throws OwsExceptionReport;
 
@@ -49,5 +48,7 @@ public interface ParameterVisitor<T> {
     NamedValue<T> visit(TextValuedParameter o)
             throws OwsExceptionReport;
 
-    
+    NamedValue<T> visit(XmlValuedParameter o)
+            throws OwsExceptionReport;
+
 }

--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/entities/parameter/ValuedParameterVisitor.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/entities/parameter/ValuedParameterVisitor.java
@@ -28,6 +28,8 @@
  */
 package org.n52.sos.ds.hibernate.entities.parameter;
 
+import org.apache.xmlbeans.XmlObject;
+
 import org.n52.sos.ds.hibernate.entities.HibernateRelations.HasUnit;
 import org.n52.sos.ogc.gml.ReferenceType;
 import org.n52.sos.ogc.om.NamedValue;
@@ -37,6 +39,7 @@ import org.n52.sos.ogc.om.values.CountValue;
 import org.n52.sos.ogc.om.values.QuantityValue;
 import org.n52.sos.ogc.om.values.TextValue;
 import org.n52.sos.ogc.om.values.Value;
+import org.n52.sos.ogc.om.values.XmlValue;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
 
 public class ValuedParameterVisitor implements ParameterVisitor<NamedValue<?>> {
@@ -44,7 +47,7 @@ public class ValuedParameterVisitor implements ParameterVisitor<NamedValue<?>> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public NamedValue visit(QuantityValuedParameter p) throws OwsExceptionReport {
-        NamedValue<Double> namedValue = new NamedValue<Double>();
+        NamedValue<Double> namedValue = new NamedValue<>();
         addName(namedValue, p);
         namedValue.setValue(new QuantityValue(p.getValue()));
         addUnit(p, namedValue.getValue());
@@ -54,7 +57,7 @@ public class ValuedParameterVisitor implements ParameterVisitor<NamedValue<?>> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public NamedValue visit(BooleanValuedParameter p) throws OwsExceptionReport {
-        NamedValue<Boolean> namedValue = new NamedValue<Boolean>();
+        NamedValue<Boolean> namedValue = new NamedValue<>();
         addName(namedValue, p);
         namedValue.setValue(new BooleanValue(p.getValue()));
         return namedValue;
@@ -63,7 +66,7 @@ public class ValuedParameterVisitor implements ParameterVisitor<NamedValue<?>> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public NamedValue visit(CategoryValuedParameter p) throws OwsExceptionReport {
-        NamedValue<String> namedValue = new NamedValue<String>();
+        NamedValue<String> namedValue = new NamedValue<>();
         addName(namedValue, p);
         namedValue.setValue(new CategoryValue(p.getValue()));
         addUnit(p, namedValue.getValue());
@@ -73,7 +76,7 @@ public class ValuedParameterVisitor implements ParameterVisitor<NamedValue<?>> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public NamedValue visit(CountValuedParameter p) throws OwsExceptionReport {
-        NamedValue<Integer> namedValue = new NamedValue<Integer>();
+        NamedValue<Integer> namedValue = new NamedValue<>();
         addName(namedValue, p);
         namedValue.setValue(new CountValue(p.getValue()));
         return namedValue;
@@ -82,22 +85,33 @@ public class ValuedParameterVisitor implements ParameterVisitor<NamedValue<?>> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public NamedValue visit(TextValuedParameter p) throws OwsExceptionReport {
-        NamedValue<String> namedValue = new NamedValue<String>();
+        NamedValue<String> namedValue = new NamedValue<>();
         addName(namedValue, p);
         namedValue.setValue(new TextValue(p.getValue()));
         return namedValue;
     }
-    
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Override
+    public NamedValue visit(XmlValuedParameter p) throws OwsExceptionReport {
+        NamedValue<XmlObject> namedValue = new NamedValue<>();
+        addName(namedValue, p);
+        namedValue.setValue(new XmlValue(p.getValueAsXml()));
+        return namedValue;
+    }
+
     protected void addUnit(ValuedParameter<?> vp, Value<?> v) {
         if (!v.isSetUnit() && vp instanceof HasUnit && ((HasUnit)vp).isSetUnit()) {
             v.setUnit(((HasUnit)vp).getUnit().getUnit());
         }
     }
-    
+
     protected NamedValue<?> addName(NamedValue<?> namedValue, ValuedParameter<?> p) {
         ReferenceType referenceType = new ReferenceType(p.getName());
         namedValue.setName(referenceType);
         return namedValue;
     }
+
+
 
 }

--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/entities/parameter/VoidParameterVisitor.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/entities/parameter/VoidParameterVisitor.java
@@ -32,7 +32,7 @@ import org.n52.sos.ogc.om.NamedValue;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
 
 public abstract class VoidParameterVisitor implements ParameterVisitor<Void> {
-    
+
     protected abstract void _visit(QuantityValuedParameter p)
             throws OwsExceptionReport;
 
@@ -47,7 +47,10 @@ public abstract class VoidParameterVisitor implements ParameterVisitor<Void> {
 
     protected abstract void _visit(TextValuedParameter p)
             throws OwsExceptionReport;
-    
+
+    protected abstract void _visit(XmlValuedParameter p)
+            throws OwsExceptionReport;
+
 
     @Override
     public NamedValue<Void> visit(QuantityValuedParameter p)
@@ -79,6 +82,13 @@ public abstract class VoidParameterVisitor implements ParameterVisitor<Void> {
 
     @Override
     public NamedValue<Void> visit(TextValuedParameter p)
+            throws OwsExceptionReport {
+        _visit(p);
+        return null;
+    }
+
+    @Override
+    public NamedValue<Void> visit(XmlValuedParameter p)
             throws OwsExceptionReport {
         _visit(p);
         return null;

--- a/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/entities/parameter/XmlValuedParameter.java
+++ b/hibernate/common/src/main/java/org/n52/sos/ds/hibernate/entities/parameter/XmlValuedParameter.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (C) 2012-2016 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *     - Apache License, version 2.0
+ *     - Apache Software License, version 1.0
+ *     - GNU Lesser General Public License, version 3
+ *     - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *     - Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public
+ * License version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ */
+package org.n52.sos.ds.hibernate.entities.parameter;
+
+import java.util.Objects;
+
+import org.apache.xmlbeans.XmlException;
+import org.apache.xmlbeans.XmlObject;
+
+import org.n52.sos.ogc.om.NamedValue;
+import org.n52.sos.ogc.ows.OwsExceptionReport;
+
+/**
+ * TODO JavaDoc
+ *
+ * @author Christian Autermann
+ */
+public class XmlValuedParameter extends Parameter<String> {
+    private static final long serialVersionUID = 3975237789394582239L;
+
+    private String value;
+
+    public XmlValuedParameter(String value) {
+        this.value = value;
+    }
+
+    public XmlValuedParameter(XmlObject value) {
+        this(encode(value));
+    }
+
+    public XmlValuedParameter() {
+        this((String)null);
+    }
+
+    @Override
+    public void accept(VoidParameterVisitor visitor)
+            throws OwsExceptionReport {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> NamedValue<T> accept(ParameterVisitor<T> visitor)
+            throws OwsExceptionReport {
+        return visitor.visit(this);
+    }
+
+    @Override
+    public String getValue() {
+        return this.value;
+    }
+
+    @Override
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public void setValue(XmlObject value) {
+        this.value = encode(value);
+    }
+
+    public XmlObject getValueAsXml() {
+        return decode(this.value);
+    }
+
+
+    @Override
+    public boolean isSetValue() {
+        return this.value != null && !this.value.isEmpty();
+    }
+
+    @Override
+    public String getValueAsString() {
+        return this.value;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 79 * hash + Objects.hashCode(this.value);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final XmlValuedParameter other = (XmlValuedParameter) obj;
+        if (!Objects.equals(this.value, other.value)) {
+            return false;
+        }
+        return true;
+    }
+
+    private static XmlObject decode(String xml)
+            throws Error {
+        try {
+            if (xml == null || xml.isEmpty()) {
+                return null;
+            } else {
+                return XmlObject.Factory.parse(xml);
+            }
+        } catch (XmlException ex) {
+            throw new Error(ex);
+        }
+    }
+
+    private static String encode(XmlObject xml) {
+        return (xml == null) ? null : xml.xmlText();
+    }
+
+}

--- a/hibernate/mappings/src/main/resources/mapping/core/Parameter.hbm.xml
+++ b/hibernate/mappings/src/main/resources/mapping/core/Parameter.hbm.xml
@@ -3,23 +3,23 @@
     "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
     <class name="org.n52.sos.ds.hibernate.entities.parameter.Parameter" table="parameter">
-    	<comment>Table to store additional obervation information (om:parameter). Mapping file: mapping/core/Parameter.hbm.xml</comment>
+        <comment>Table to store additional obervation information (om:parameter). Mapping file: mapping/core/Parameter.hbm.xml</comment>
         <id name="parameterId" type="long">
             <column name="parameterId">
-            	<comment>Table primary key</comment>
+                <comment>Table primary key</comment>
             </column>
             <generator class="native">
-            	<param name="sequence">parameterId_seq</param>
+                <param name="sequence">parameterId_seq</param>
             </generator>
         </id>
         <property name="observationId" type="long">
             <column name="observationId" not-null="true">
-            	<comment>Foreign Key (FK) to the related observation. Contains "observation".observationId</comment>
+                <comment>Foreign Key (FK) to the related observation. Contains "observation".observationId</comment>
             </column>
         </property>
         <property name="name" type="string">
             <column name="name" not-null="true" index="paramNameIdx">
-            	<comment>Parameter name</comment>
+                <comment>Parameter name</comment>
             </column>
         </property>
         <joined-subclass name="org.n52.sos.ds.hibernate.entities.parameter.BooleanValuedParameter"
@@ -27,101 +27,116 @@
                          table="booleanParameterValue"
                          check="value in ('T','F')">
             <comment>Value table for boolean parameter</comment>
-        	<key foreign-key="parameterBooleanValueFk">
-	        	<column name="parameterId" >
-	        		<comment>Foreign Key (FK) to the related parameter from the parameter table. Contains "parameter".parameterid</comment>
-	        	</column>
-        	</key>
-        	<property name="value" 
-        			  type="org.hibernate.type.TrueFalseType">
-         		<column name="value"  index="booleanParamIdx">
-         			<comment>Boolean parameter value</comment>
-         		</column>
-         	</property>
+            <key foreign-key="parameterBooleanValueFk">
+                <column name="parameterId" >
+                    <comment>Foreign Key (FK) to the related parameter from the parameter table. Contains "parameter".parameterid</comment>
+                </column>
+            </key>
+            <property name="value"
+                      type="org.hibernate.type.TrueFalseType">
+                <column name="value"  index="booleanParamIdx">
+                    <comment>Boolean parameter value</comment>
+                </column>
+            </property>
         </joined-subclass>
         <joined-subclass name="org.n52.sos.ds.hibernate.entities.parameter.CategoryValuedParameter"
                          extends="org.n52.sos.ds.hibernate.entities.parameter.ValuedParameter"
                          table="categoryParameterValue">
             <comment>Value table for category parameter</comment>
-        	<key foreign-key="parameterCategoryValueFk">
-	        	<column name="parameterId" >
-	        		<comment>Foreign Key (FK) to the related parameter from the parameter table. Contains "parameter".parameterid</comment>
-	        	</column>
-        	</key>
-         	<property name="value" 
-         			  type="string">
-         		<column name="value" index="categoryParamIdx">
-         			<comment>Category parameter value</comment>
-         		</column>
-         	</property>
-         	<many-to-one name="unit"
-	                     class="org.n52.sos.ds.hibernate.entities.Unit"
-	                     fetch="select"
-	                     lazy="no-proxy"
-	                     foreign-key="catParamValueUnitFk">
-	            <column name="unitId"
-	                    not-null="false">
-	            	<comment>Foreign Key (FK) to the related unit of measure. Contains "unit".unitid. Optional</comment>
-	            </column>
-	        </many-to-one>
+            <key foreign-key="parameterCategoryValueFk">
+                <column name="parameterId" >
+                    <comment>Foreign Key (FK) to the related parameter from the parameter table. Contains "parameter".parameterid</comment>
+                </column>
+            </key>
+            <property name="value"
+                       type="string">
+                <column name="value" index="categoryParamIdx">
+                    <comment>Category parameter value</comment>
+                </column>
+            </property>
+            <many-to-one name="unit"
+                          class="org.n52.sos.ds.hibernate.entities.Unit"
+                          fetch="select"
+                          lazy="no-proxy"
+                          foreign-key="catParamValueUnitFk">
+                <column name="unitId"
+                        not-null="false">
+                    <comment>Foreign Key (FK) to the related unit of measure. Contains "unit".unitid. Optional</comment>
+                </column>
+            </many-to-one>
         </joined-subclass>
         <joined-subclass name="org.n52.sos.ds.hibernate.entities.parameter.CountValuedParameter"
                          extends="org.n52.sos.ds.hibernate.entities.parameter.ValuedParameter"
                          table="countParameterValue">
             <comment>Value table for count parameter</comment>
-        	<key foreign-key="parameterCountValueFk">
-	        	<column name="parameterId" >
-	        		<comment>Foreign Key (FK) to the related parameter from the parameter table. Contains "parameter".parameterid</comment>
-	        	</column>
-        	</key>
-        	<property name="value" 
-        			  type="integer">
-         		<column name="value" index="countParamIdx">
-         			<comment>Count parameter value</comment>
-         		</column>
-         	</property>
+            <key foreign-key="parameterCountValueFk">
+                <column name="parameterId" >
+                    <comment>Foreign Key (FK) to the related parameter from the parameter table. Contains "parameter".parameterid</comment>
+                </column>
+            </key>
+            <property name="value"
+                      type="integer">
+                <column name="value" index="countParamIdx">
+                    <comment>Count parameter value</comment>
+                </column>
+            </property>
         </joined-subclass>
         <joined-subclass name="org.n52.sos.ds.hibernate.entities.parameter.QuantityValuedParameter"
                          extends="org.n52.sos.ds.hibernate.entities.parameter.ValuedParameter"
                          table="numericParameterValue">
-                        <comment>Value table for numeric/Measurment parameter</comment>
+            <comment>Value table for numeric/Measurment parameter</comment>
             <key foreign-key="parameterNumericValueFk">
-                 <column name="parameterId" >
-	        		<comment>Foreign Key (FK) to the related parameter from the parameter table. Contains "parameter".parameterid</comment>
-	        	</column>
-	        </key>
-            <property name="value" 
-            		  type="double">
-         		<column name="value" index="quantityParamIdx">
-         			<comment>Numeric/Quantity parameter value</comment>
-         		</column>
-         	</property>
-         	<many-to-one name="unit"
-	                     class="org.n52.sos.ds.hibernate.entities.Unit"
-	                     fetch="select"
-	                     lazy="no-proxy"
-	                     foreign-key="quanParamValueUnitFk">
-	            <column name="unitId"
-	                    not-null="false">
-	            	<comment>Foreign Key (FK) to the related unit of measure. Contains "unit".unitid. Optional</comment>
-	            </column>
-	        </many-to-one>
+                <column name="parameterId" >
+                    <comment>Foreign Key (FK) to the related parameter from the parameter table. Contains "parameter".parameterid</comment>
+                </column>
+            </key>
+            <property name="value"
+                      type="double">
+                <column name="value" index="quantityParamIdx">
+                    <comment>Numeric/Quantity parameter value</comment>
+                </column>
+            </property>
+            <many-to-one name="unit"
+                          class="org.n52.sos.ds.hibernate.entities.Unit"
+                          fetch="select"
+                          lazy="no-proxy"
+                          foreign-key="quanParamValueUnitFk">
+                <column name="unitId"
+                        not-null="false">
+                    <comment>Foreign Key (FK) to the related unit of measure. Contains "unit".unitid. Optional</comment>
+                </column>
+            </many-to-one>
         </joined-subclass>
         <joined-subclass name="org.n52.sos.ds.hibernate.entities.parameter.TextValuedParameter"
                          extends="org.n52.sos.ds.hibernate.entities.parameter.ValuedParameter"
                          table="textParameterValue">
             <comment>Value table for text parameter</comment>
-        	<key foreign-key="parameterTextValueFk">
-	        	<column name="parameterId" >
-	        		<comment>Foreign Key (FK) to the related parameter from the parameter table. Contains "parameter".parameterid</comment>
-	        	</column>
-        	</key>
-        	<property name="value" 
-        			  type="string">
-         		<column name="value" index="textParamIdx">
-         			<comment>Text parameter value</comment>
-         		</column>
-         	</property>
+            <key foreign-key="parameterTextValueFk">
+                <column name="parameterId" >
+                    <comment>Foreign Key (FK) to the related parameter from the parameter table. Contains "parameter".parameterid</comment>
+                </column>
+            </key>
+            <property name="value"
+                      type="string">
+                <column name="value" index="textParamIdx">
+                    <comment>Text parameter value</comment>
+                </column>
+            </property>
+        </joined-subclass>
+        <joined-subclass name="org.n52.sos.ds.hibernate.entities.parameter.XmlValuedParameter"
+                         extends="org.n52.sos.ds.hibernate.entities.parameter.ValuedParameter"
+                         table="xmlParameterValue">
+            <comment>Value table for XML parameter</comment>
+            <key foreign-key="parameterXmlValueFk">
+                <column name="parameterId" >
+                    <comment>Foreign Key (FK) to the related parameter from the parameter table. Contains "parameter".parameterid</comment>
+                </column>
+            </key>
+            <property name="value" type="text">
+                <column name="value" index="xmlParamIdx">
+                    <comment>XML parameter value</comment>
+                </column>
+            </property>
         </joined-subclass>
     </class>
 </hibernate-mapping>

--- a/misc/db/PostgreSQL/PG_update_43_44.sql
+++ b/misc/db/PostgreSQL/PG_update_43_44.sql
@@ -50,3 +50,8 @@ alter table public.compositeObservation add constraint observationParentFK forei
 -- spatial index
 create index featureGeomIdx on public.featureOfInterest USING GIST (geom);
 create index samplingGeomIdx on public.observation USING GIST (samplingGeometry);
+
+-- XML based parameter values
+CREATE TABLE public.xmlparametervalue (parameterid bigint PRIMARY KEY, value text);
+ALTER TABLE public.xmlparametervalue ADD CONSTRAINT parameterxmlvaluefk FOREIGN KEY (parameterid) REFERENCES public.parameter (parameterid)
+CREATE INDEX xmlparamidx ON public.xmlparametervalue USING btree (value);


### PR DESCRIPTION
Example `InsertObservation` request (using the offering created by the `Batch` request example):

```xml
<?xml version="1.0" encoding="UTF-8"?>
<sos:InsertObservation
    xmlns:sos="http://www.opengis.net/sos/2.0"
    xmlns:gml="http://www.opengis.net/gml/3.2"
    xmlns:om="http://www.opengis.net/om/2.0"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:un="http://www.uncertml.org/2.0" 
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
    service="SOS" version="2.0.0">
    <sos:offering>http://www.52north.org/test/offering/1</sos:offering>
    <sos:observation>
        <om:OM_Observation gml:id="observation">
            <om:type xlink:href="http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement"/>
            <om:phenomenonTime>
                <gml:TimeInstant gml:id="timeInstant">
                    <gml:timePosition>2012-07-31T17:45:15.000+00:00</gml:timePosition>
                </gml:TimeInstant>
            </om:phenomenonTime>
            <om:resultTime xlink:href="#timeInstant"/>
            <om:procedure xlink:href="http://www.52north.org/test/procedure/1"/>
            <om:parameter>
                <om:NamedValue>
                    <om:name xlink:href="https://en.wikipedia.org/wiki/Uncertainty" />
                    <om:value>
                        <un:NormalDistribution>
                            <un:mean>3.14</un:mean>
                            <un:variance>3.14</un:variance>
                        </un:NormalDistribution>
                    </om:value>
                </om:NamedValue>
            </om:parameter>
            <om:observedProperty xlink:href="http://www.52north.org/test/observableProperty/1"/>
            <om:featureOfInterest xlink:href="http://www.52north.org/test/featureOfInterest/1"/>
            <om:result xsi:type="gml:MeasureType" uom="test_unit_9_3">0.28</om:result>
        </om:OM_Observation>
    </sos:observation>
</sos:InsertObservation>
```
Example `GetObservation` request:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<sos:GetObservation service="SOS" version="2.0.0"
    xmlns:sos="http://www.opengis.net/sos/2.0" 
    xmlns:fes="http://www.opengis.net/fes/2.0"
    xmlns:gml="http://www.opengis.net/gml/3.2">
    <sos:procedure>http://www.52north.org/test/procedure/1</sos:procedure>
    <sos:offering>http://www.52north.org/test/offering/1</sos:offering>
    <sos:observedProperty>http://www.52north.org/test/observableProperty/1</sos:observedProperty>
    <sos:temporalFilter>
        <fes:During>
            <fes:ValueReference>phenomenonTime</fes:ValueReference>
            <gml:TimePeriod gml:id="tp_1">
                <gml:beginPosition>2012-07-31T17:45:14.000+00:00</gml:beginPosition>
                <gml:endPosition>2012-07-31T17:45:16.000+00:00</gml:endPosition>
            </gml:TimePeriod>
        </fes:During>
    </sos:temporalFilter>
    <sos:featureOfInterest>http://www.52north.org/test/featureOfInterest/1</sos:featureOfInterest>
    <sos:responseFormat>http://www.opengis.net/om/2.0</sos:responseFormat>
</sos:GetObservation>
```

Example `GetObservation` response:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<sos:GetObservationResponse xmlns:sos="http://www.opengis.net/sos/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:om="http://www.opengis.net/om/2.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/sos/2.0 http://schemas.opengis.net/sos/2.0/sosGetObservation.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd http://www.opengis.net/om/2.0 http://schemas.opengis.net/om/2.0/observation.xsd">
  <sos:observationData>
    <om:OM_Observation gml:id="o_6DC6535239753A7072FA9C71DE9CE7BDC1ABF6B8">
      <om:type xlink:href="http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement"/>
      <om:phenomenonTime>
        <gml:TimeInstant gml:id="phenomenonTime_85">
          <gml:timePosition>2012-07-31T17:45:15.000Z</gml:timePosition>
        </gml:TimeInstant>
      </om:phenomenonTime>
      <om:resultTime xlink:href="#phenomenonTime_85"/>
      <om:procedure xlink:href="http://www.52north.org/test/procedure/1" xlink:title="con terra"/>
      <om:parameter>
        <om:NamedValue>
          <om:name xlink:href="https://en.wikipedia.org/wiki/Uncertainty"/>
          <om:value>
            <un:NormalDistribution xmlns:un="http://www.uncertml.org/2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
              <un:mean>3.14</un:mean>
              <un:variance>3.14</un:variance>
            </un:NormalDistribution>
          </om:value>
        </om:NamedValue>
      </om:parameter>
      <om:observedProperty xlink:href="http://www.52north.org/test/observableProperty/1" xlink:title="test_observable_property_1"/>
      <om:featureOfInterest xlink:href="http://www.52north.org/test/featureOfInterest/1" xlink:title="con terra"/>
      <om:result xmlns:ns="http://www.opengis.net/gml/3.2" uom="test_unit_9_3" xsi:type="ns:MeasureType">0.28</om:result>
    </om:OM_Observation>
  </sos:observationData>
</sos:GetObservationResponse>
```
