### PR TITLE
Fixes #452

### DIFF
--- a/hibernate/datasource/common/src/main/java/org/n52/sos/ds/datasource/AbstractHibernateDatasource.java
+++ b/hibernate/datasource/common/src/main/java/org/n52/sos/ds/datasource/AbstractHibernateDatasource.java
@@ -543,7 +543,7 @@ public abstract class AbstractHibernateDatasource extends AbstractHibernateCoreD
         return null;
     }
 
-    private String checkCatalog(Connection conn) throws SQLException {
+    protected String checkCatalog(Connection conn) throws SQLException {
         return conn.getCatalog();
     }
 


### PR DESCRIPTION
'Clear Database' utility fails to remove data from PostgreSQL
Use qualified name (includes quoted name and scheme prefix) when creating truncate script.