### PR TITLE
Upgrade maven-source-plugin, add test sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1184,12 +1184,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
+                            <goal>test-jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
This PR upgrades `maven-source-plugin` and adds test source jars (useful for modules producing `test` jar artifacts).