### PR TITLE
Add ObservationEncodingsTest, SOS 1.0.0 OperationEncoderKey for coding-json GetObs

### DIFF
--- a/webapp/src/test/java/org/n52/sos/service/it/SOS40ComplianceTestSuite.java
+++ b/webapp/src/test/java/org/n52/sos/service/it/SOS40ComplianceTestSuite.java
@@ -85,6 +85,7 @@ public class SOS40ComplianceTestSuite
             org.n52.sos.service.it.functional.ComplexObservationTest.class,
             org.n52.sos.service.it.functional.ContentNegotiationEndpointTest.class,
             org.n52.sos.service.it.functional.DescribeSensorProcedureDescriptionFormatTest.class,
+            org.n52.sos.service.it.functional.ObservationEncodingsTest.class,
 
             org.n52.sos.service.it.v2.kvp.DeleteObservationTest.class,
             org.n52.sos.service.it.v2.kvp.DeleteSensorTest.class,

--- a/webapp/src/test/java/org/n52/sos/service/it/functional/AbstractObservationTest.java
+++ b/webapp/src/test/java/org/n52/sos/service/it/functional/AbstractObservationTest.java
@@ -1,0 +1,323 @@
+/**
+ * Copyright (C) 2012-2016 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *     - Apache License, version 2.0
+ *     - Apache Software License, version 1.0
+ *     - GNU Lesser General Public License, version 3
+ *     - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *     - Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public
+ * License version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ */
+package org.n52.sos.service.it.functional;
+
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+
+import javax.xml.namespace.NamespaceContext;
+
+import org.apache.xmlbeans.XmlObject;
+import org.apache.xmlbeans.XmlOptions;
+import org.joda.time.DateTime;
+import org.junit.rules.ErrorCollector;
+import org.n52.sos.config.SettingDefinition;
+import org.n52.sos.config.SettingValue;
+import org.n52.sos.config.SettingValueFactory;
+import org.n52.sos.config.SettingsManager;
+import org.n52.sos.ds.ConnectionProviderException;
+import org.n52.sos.exception.ConfigurationException;
+import org.n52.sos.exception.ows.concrete.InvalidSridException;
+import org.n52.sos.ogc.OGCConstants;
+import org.n52.sos.ogc.gml.CodeWithAuthority;
+import org.n52.sos.ogc.gml.GmlConstants;
+import org.n52.sos.ogc.gml.time.TimeInstant;
+import org.n52.sos.ogc.gml.time.TimePeriod;
+import org.n52.sos.ogc.om.AbstractPhenomenon;
+import org.n52.sos.ogc.om.OmConstants;
+import org.n52.sos.ogc.om.OmObservableProperty;
+import org.n52.sos.ogc.om.OmObservation;
+import org.n52.sos.ogc.om.OmObservationConstellation;
+import org.n52.sos.ogc.om.SingleObservationValue;
+import org.n52.sos.ogc.om.features.SfConstants;
+import org.n52.sos.ogc.om.features.samplingFeatures.SamplingFeature;
+import org.n52.sos.ogc.om.values.Value;
+import org.n52.sos.ogc.ows.OWSConstants;
+import org.n52.sos.ogc.ows.OwsExceptionReport;
+import org.n52.sos.ogc.sensorML.SensorML;
+import org.n52.sos.ogc.sensorML.SensorMLConstants;
+import org.n52.sos.ogc.sensorML.elements.SmlCapabilities;
+import org.n52.sos.ogc.sensorML.elements.SmlIdentifier;
+import org.n52.sos.ogc.sos.Sos2Constants;
+import org.n52.sos.ogc.sos.SosConstants;
+import org.n52.sos.ogc.swe.SweConstants;
+import org.n52.sos.ogc.swe.SweField;
+import org.n52.sos.ogc.swe.SweSimpleDataRecord;
+import org.n52.sos.ogc.swe.simpleType.SweText;
+import org.n52.sos.service.it.AbstractComplianceSuiteTest;
+import org.n52.sos.service.it.Client;
+import org.n52.sos.util.CodingHelper;
+import org.n52.sos.util.JTSHelper;
+import org.n52.sos.util.XmlOptionsHelper;
+import org.n52.sos.util.http.MediaTypes;
+import org.n52.sos.w3c.W3CConstants;
+
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.Iterators;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+
+import net.opengis.sos.x20.GetObservationResponseDocument;
+import net.opengis.sos.x20.InsertObservationDocument;
+import net.opengis.sos.x20.InsertObservationType;
+import net.opengis.sos.x20.SosInsertionMetadataType;
+import net.opengis.swes.x20.InsertSensorDocument;
+import net.opengis.swes.x20.InsertSensorType;
+
+public abstract class AbstractObservationTest extends AbstractComplianceSuiteTest {
+    private static final GeometryFactory GEOM_FACTORY_4326 = JTSHelper.getGeometryFactoryForSRID(4326);
+    private static final String APPLICATION_XML = MediaTypes.APPLICATION_XML.toString();
+    protected static final String CODESPACE = "codespace";
+
+    protected void checkObservationCount(int count, XmlObject response, ErrorCollector errors) {
+        assertThat(response, is(instanceOf(GetObservationResponseDocument.class)));
+        GetObservationResponseDocument document = (GetObservationResponseDocument) response;
+        errors.checkThat(document.getGetObservationResponse().getObservationDataArray(), arrayWithSize(count));
+    }
+
+    protected Client pox() {
+        return pox(APPLICATION_XML);
+    }
+
+    protected Client pox(String accept) {
+        return getExecutor().pox()
+                .contentType(APPLICATION_XML)
+                .accept(accept);
+    }
+
+    protected Client kvp(Enum<?> operation) {
+        return kvp(Sos2Constants.SERVICEVERSION, APPLICATION_XML, operation);
+    }
+
+    protected Client kvp(String version, String accept, Enum<?> operation) {
+        return getExecutor().kvp()
+                .accept(accept)
+                .query(OWSConstants.RequestParams.service, SosConstants.SOS)
+                .query(OWSConstants.RequestParams.version, version)
+                .query(OWSConstants.RequestParams.request, operation);
+    }
+
+    protected InsertSensorDocument createInsertSensorRequest(String procedure, String offering,
+            String observableProperty) throws OwsExceptionReport {
+        return createInsertSensorRequest(createProcedure(procedure, offering, createObservableProperty(observableProperty)),
+                observableProperty);
+    }
+
+    protected InsertSensorDocument createInsertSensorRequest(SensorML procedure, String observableProperty) throws OwsExceptionReport {
+        InsertSensorDocument document = InsertSensorDocument.Factory.newInstance();
+        InsertSensorType insertSensor = document.addNewInsertSensor();
+        insertSensor.setService(SosConstants.SOS);
+        insertSensor.setVersion(Sos2Constants.SERVICEVERSION);
+        insertSensor.addObservableProperty(observableProperty);
+        insertSensor.setProcedureDescriptionFormat(SensorMLConstants.NS_SML);
+        insertSensor.addNewMetadata().addNewInsertionMetadata().set(createSensorInsertionMetadata());
+        insertSensor.addNewProcedureDescription().set(CodingHelper.encodeObjectToXml(SensorMLConstants.NS_SML, procedure));
+        return document;
+    }
+
+    private SosInsertionMetadataType createSensorInsertionMetadata() {
+        SosInsertionMetadataType sosInsertionMetadata = SosInsertionMetadataType.Factory.newInstance();
+        sosInsertionMetadata.addFeatureOfInterestType(OGCConstants.UNKNOWN);
+        sosInsertionMetadata.addFeatureOfInterestType(SfConstants.SAMPLING_FEAT_TYPE_SF_SAMPLING_POINT);
+        for (String observationType : OmConstants.OBSERVATION_TYPES) {
+            sosInsertionMetadata.addObservationType(observationType);
+        }
+        return sosInsertionMetadata;
+    }
+
+    protected SensorML createProcedure(String procedure, String offering, AbstractPhenomenon observableProperty) {
+        SensorML wrapper = new SensorML();
+        org.n52.sos.ogc.sensorML.System sensorML = new org.n52.sos.ogc.sensorML.System();
+        wrapper.addMember(sensorML);
+        sensorML.addIdentifier(new SmlIdentifier(OGCConstants.UNIQUE_ID, OGCConstants.URN_UNIQUE_IDENTIFIER, procedure));
+        sensorML.addCapabilities(createOfferingCapabilities(offering));
+        sensorML.addPhenomenon(observableProperty);
+        wrapper.setIdentifier(new CodeWithAuthority(procedure, CODESPACE));
+        return wrapper;
+    }
+
+    private SmlCapabilities createOfferingCapabilities(String offering) {
+        return new SmlCapabilities(SensorMLConstants.ELEMENT_NAME_OFFERINGS,
+                new SweSimpleDataRecord().addField(createOfferingField(offering)));
+    }
+
+    private SweField createOfferingField(String offering) {
+        return new SweField(offering, new SweText().setValue(offering).setDefinition(OGCConstants.URN_OFFERING_ID));
+    }
+
+    protected InsertObservationDocument createInsertObservationRequest(OmObservation observation, String offering)
+            throws OwsExceptionReport {
+        return createInsertObservationRequest(Collections.singleton(observation), offering);
+    }
+
+    protected InsertObservationDocument createInsertObservationRequest(Collection<OmObservation> observations, String offering)
+            throws OwsExceptionReport {
+        InsertObservationDocument document = InsertObservationDocument.Factory.newInstance();
+        InsertObservationType insertObservation = document.addNewInsertObservation();
+        insertObservation.setService(SosConstants.SOS);
+        insertObservation.setVersion(Sos2Constants.SERVICEVERSION);
+        insertObservation.addNewOffering().setStringValue(offering);
+        if (observations != null) {
+            for (OmObservation observation : observations) {
+                insertObservation.addNewObservation().addNewOMObservation().set(CodingHelper
+                        .encodeObjectToXml(OmConstants.NS_OM_2, observation));
+            }
+        }
+        return document;
+    }
+
+    protected OmObservation createObservation(String type, String procedure, String offering, AbstractPhenomenon observableProperty,
+            SamplingFeature samplingFeature, DateTime time, Value<?> value) {
+        TimeInstant resultTime = new TimeInstant(time);
+        TimeInstant phenomenonTime = new TimeInstant(time);
+        TimePeriod validTime = new TimePeriod(time.minusMinutes(5), time.plusMinutes(5));
+
+        OmObservation observation = new OmObservation();
+        observation.setObservationConstellation(createObservationConstellation(procedure, offering,
+                type, observableProperty, samplingFeature));
+        observation.setResultTime(resultTime);
+        observation.setValidTime(validTime);
+        observation.setValue(new SingleObservationValue<>(phenomenonTime, value));
+
+        return observation;
+    }
+
+    private OmObservationConstellation createObservationConstellation(String procedure, String offering, String observationType,
+            AbstractPhenomenon observableProperty, SamplingFeature samplingFeature) {
+        OmObservationConstellation observationConstellation = new OmObservationConstellation();
+        observationConstellation.setFeatureOfInterest(samplingFeature);
+        observationConstellation.setObservableProperty(observableProperty);
+        observationConstellation.setObservationType(observationType);
+        observationConstellation.setProcedure(createProcedure(procedure, offering, observableProperty));
+        return observationConstellation;
+    }
+
+    protected static SamplingFeature createFeature(String featureOfInterest, Geometry geom) {
+        SamplingFeature samplingFeature = new SamplingFeature(new CodeWithAuthority(featureOfInterest));
+        try {
+            samplingFeature.setGeometry(geom);
+        } catch (InvalidSridException e) {
+            throw new IllegalArgumentException("Invalid srid", e);
+        }
+        return samplingFeature;
+    }
+
+    protected OmObservableProperty createObservableProperty(String observableProperty) {
+        return new OmObservableProperty(observableProperty);
+    }
+
+    protected static void changeSetting(String setting, String value) {
+        SettingsManager sm = SettingsManager.getInstance();
+        SettingValueFactory sf = sm.getSettingFactory();
+        SettingDefinition<?, ?> sd = sm.getDefinitionByKey(setting);
+        SettingValue<?> sv = sf.newSettingValue(sd, value);
+        try {
+            sm.changeSetting(sv);
+        } catch (ConfigurationException |
+                 ConnectionProviderException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    protected static XmlOptions getXmlOptions() {
+        return XmlOptionsHelper.getInstance().getXmlOptions();
+    }
+
+    protected static class NamespaceContextImpl implements NamespaceContext {
+        private final ImmutableBiMap<String, String> map = ImmutableBiMap
+                .<String, String>builder()
+                .put(Sos2Constants.NS_SOS_PREFIX, Sos2Constants.NS_SOS_20)
+                .put(OWSConstants.NS_OWS_PREFIX, OWSConstants.NS_OWS)
+                .put(SweConstants.NS_SWE_PREFIX, SweConstants.NS_SWE_20)
+                .put(OmConstants.NS_OM_PREFIX, OmConstants.NS_OM_2)
+                .put(W3CConstants.NS_XSI_PREFIX, W3CConstants.NS_XSI)
+                .put(W3CConstants.NS_XLINK_PREFIX, W3CConstants.NS_XLINK)
+                .put(GmlConstants.NS_GML_PREFIX, GmlConstants.NS_GML_32)
+                .put(SfConstants.NS_SAMS_PREFIX, SfConstants.NS_SAMS)
+                .build();
+
+        @Override
+        public String getNamespaceURI(String prefix) {
+            return map.get(prefix);
+        }
+
+        @Override
+        public String getPrefix(String namespaceURI) {
+            return map.inverse().get(namespaceURI);
+        }
+
+        @Override
+        public Iterator<String> getPrefixes(String namespaceURI) {
+            return Iterators.singletonIterator(getPrefix(namespaceURI));
+        }
+    }
+
+    protected static Point createPoint4326(double lat, double lng) {
+        return GEOM_FACTORY_4326.createPoint(new Coordinate(lng, lat));
+    }
+
+    protected static Point createPoint4326(double lat, double lng, double height) {
+        return GEOM_FACTORY_4326.createPoint(new Coordinate(lng, lat, height));
+    }
+
+    protected static Point createRandomPoint4326() {
+        return GEOM_FACTORY_4326.createPoint(new Coordinate(randomLng(), randomLat(),
+                randomInRange(-10.0, 50.0, 2)));
+    }
+
+    protected static double randomLng(){
+        //make test data lngs three digits for easy differentiation from lats
+        double lng = randomInRange(100.0, 180.0, 6);
+        //return a negative number if lng is even
+        if ((int) Math.round(lng) % 2 == 0) {
+            return 0 - lng;
+        } else {
+            return lng;
+        }
+    }
+
+    protected static double randomLat(){
+        //stay away from the poles because they often break software
+        return randomInRange(-75.0, 75.0, 6);
+    }
+
+    protected static double randomInRange(double min, double max, int decimalPlaces){
+        double unroundedValue = min + Math.random() * (max - min);
+        double co = Math.pow(10, decimalPlaces);
+        return Math.round(unroundedValue * co) / co;
+    }
+}

--- a/webapp/src/test/java/org/n52/sos/service/it/functional/ComplexObservationTest.java
+++ b/webapp/src/test/java/org/n52/sos/service/it/functional/ComplexObservationTest.java
@@ -37,66 +37,27 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
-import java.util.Iterator;
-
-import javax.xml.namespace.NamespaceContext;
-
-import net.opengis.ows.x11.ExceptionReportDocument;
-import net.opengis.sos.x20.GetObservationResponseDocument;
-import net.opengis.sos.x20.InsertObservationDocument;
-import net.opengis.sos.x20.InsertObservationResponseDocument;
-import net.opengis.sos.x20.InsertObservationType;
-import net.opengis.sos.x20.SosInsertionMetadataType;
-import net.opengis.swes.x20.InsertSensorDocument;
-import net.opengis.swes.x20.InsertSensorResponseDocument;
-import net.opengis.swes.x20.InsertSensorType;
-
 import org.apache.xmlbeans.XmlObject;
-import org.apache.xmlbeans.XmlOptions;
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
-import org.w3c.dom.Node;
 import org.n52.sos.cache.ContentCache;
-import org.n52.sos.config.SettingDefinition;
-import org.n52.sos.config.SettingValue;
-import org.n52.sos.config.SettingValueFactory;
-import org.n52.sos.config.SettingsManager;
-import org.n52.sos.ds.ConnectionProviderException;
 import org.n52.sos.ds.hibernate.H2Configuration;
-import org.n52.sos.exception.ConfigurationException;
 import org.n52.sos.exception.ows.OwsExceptionCode;
-import org.n52.sos.ogc.OGCConstants;
-import org.n52.sos.ogc.gml.CodeWithAuthority;
-import org.n52.sos.ogc.gml.GmlConstants;
-import org.n52.sos.ogc.gml.time.TimeInstant;
-import org.n52.sos.ogc.gml.time.TimePeriod;
-import org.n52.sos.ogc.om.AbstractPhenomenon;
 import org.n52.sos.ogc.om.OmCompositePhenomenon;
 import org.n52.sos.ogc.om.OmConstants;
 import org.n52.sos.ogc.om.OmObservableProperty;
 import org.n52.sos.ogc.om.OmObservation;
-import org.n52.sos.ogc.om.OmObservationConstellation;
-import org.n52.sos.ogc.om.SingleObservationValue;
-import org.n52.sos.ogc.om.features.SfConstants;
-import org.n52.sos.ogc.om.features.samplingFeatures.SamplingFeature;
 import org.n52.sos.ogc.om.values.ComplexValue;
 import org.n52.sos.ogc.om.values.QuantityValue;
-import org.n52.sos.ogc.ows.OWSConstants;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
-import org.n52.sos.ogc.sensorML.SensorML;
-import org.n52.sos.ogc.sensorML.SensorMLConstants;
-import org.n52.sos.ogc.sensorML.elements.SmlCapabilities;
-import org.n52.sos.ogc.sensorML.elements.SmlIdentifier;
 import org.n52.sos.ogc.sos.Sos2Constants;
 import org.n52.sos.ogc.sos.SosConstants;
-import org.n52.sos.ogc.swe.SweConstants;
 import org.n52.sos.ogc.swe.SweDataRecord;
 import org.n52.sos.ogc.swe.SweField;
-import org.n52.sos.ogc.swe.SweSimpleDataRecord;
 import org.n52.sos.ogc.swe.simpleType.SweBoolean;
 import org.n52.sos.ogc.swe.simpleType.SweCategory;
 import org.n52.sos.ogc.swe.simpleType.SweCount;
@@ -106,51 +67,49 @@ import org.n52.sos.request.operator.RequestOperatorKey;
 import org.n52.sos.request.operator.RequestOperatorRepository;
 import org.n52.sos.service.Configurator;
 import org.n52.sos.service.ServiceSettings;
-import org.n52.sos.service.it.AbstractComplianceSuiteTest;
-import org.n52.sos.service.it.Client;
 import org.n52.sos.service.operator.ServiceOperatorKey;
-import org.n52.sos.util.CodingHelper;
-import org.n52.sos.util.XmlOptionsHelper;
-import org.n52.sos.util.http.MediaTypes;
-import org.n52.sos.w3c.W3CConstants;
+import org.w3c.dom.Node;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableBiMap;
-import com.google.common.collect.Iterators;
 
-public class ComplexObservationTest extends AbstractComplianceSuiteTest {
+import net.opengis.ows.x11.ExceptionReportDocument;
+import net.opengis.sos.x20.GetObservationResponseDocument;
+import net.opengis.sos.x20.InsertObservationDocument;
+import net.opengis.sos.x20.InsertObservationResponseDocument;
+import net.opengis.swes.x20.InsertSensorDocument;
+import net.opengis.swes.x20.InsertSensorResponseDocument;
+
+public class ComplexObservationTest extends AbstractObservationTest {
     private static final NamespaceContextImpl NS_CTX = new NamespaceContextImpl();
+    private static final String FEATURE_OF_INTEREST = "featureOfInterest";
     private static final String COMPLEX_OBSERVATION_PROCEDURE = "procedure";
     private static final String COMPLEX_OBSERVATION_OFFERING = "offering";
     private static final String NUMERIC_OBSERVATION_PROCEDURE = "numericProcedure";
     private static final String NUMERIC_OBSERVATION_OFFERING = "numericOffering";
-    private static final String PARENT_OBSERVABLE_PROPERTY = "http://example.tld/phenomenon/parent";
-    private static final String CHILD_OBSERVABLE_PROPERTY_5 = "http://example.tld/phenomenon/child/5";
-    private static final String CHILD_OBSERVABLE_PROPERTY_4 = "http://example.tld/phenomenon/child/4";
-    private static final String CHILD_OBSERVABLE_PROPERTY_3 = "http://example.tld/phenomenon/child/3";
-    private static final String CHILD_OBSERVABLE_PROPERTY_2 = "http://example.tld/phenomenon/child/2";
-    private static final String CHILD_OBSERVABLE_PROPERTY_1 = "http://example.tld/phenomenon/child/1";
-    private static final String APPLICATION_XML = MediaTypes.APPLICATION_XML.toString();
-    private static final String FEATURE_OF_INTEREST = "featureOfInterest";
-    private static final String OFFERING_CAPABILITIES_NAME = "offerings";
-    private static final String UNIQUE_ID_NAME = "uniqueID";
-    private static final String[] CHILD_OBSERVABLE_PROPERTIES = {
-        CHILD_OBSERVABLE_PROPERTY_1,
-        CHILD_OBSERVABLE_PROPERTY_2,
-        CHILD_OBSERVABLE_PROPERTY_3,
-        CHILD_OBSERVABLE_PROPERTY_4,
-        CHILD_OBSERVABLE_PROPERTY_5
-    };
-    private static final String[] ALL_OBSERVABLE_PROPERTIES = {
-        PARENT_OBSERVABLE_PROPERTY,
-        CHILD_OBSERVABLE_PROPERTY_1,
-        CHILD_OBSERVABLE_PROPERTY_2,
-        CHILD_OBSERVABLE_PROPERTY_3,
-        CHILD_OBSERVABLE_PROPERTY_4,
-        CHILD_OBSERVABLE_PROPERTY_5
-    };
+    private static final String COMPOSITE_OBSERVABLE_PROPERTY = "http://example.tld/phenomenon/composite";
+    private static final String BOOLEAN_OBSERVABLE_PROPERTY = "http://example.tld/phenomenon/boolean";
+    private static final String CATEGORY_OBSERVABLE_PROPERTY = "http://example.tld/phenomenon/category";
+    private static final String COUNT_OBSERVABLE_PROPERTY = "http://example.tld/phenomenon/count";
+    private static final String QUANTITY_OBSERVABLE_PROPERTY = "http://example.tld/phenomenon/quantity";
+    private static final String TEXT_OBSERVABLE_PROPERTY = "http://example.tld/phenomenon/text";
     private static final String UNIT = "unit";
-    private static final String CODESPACE = "codespace";
+
+    protected static final String[] CHILD_OBSERVABLE_PROPERTIES = {
+        BOOLEAN_OBSERVABLE_PROPERTY,
+        CATEGORY_OBSERVABLE_PROPERTY,
+        COUNT_OBSERVABLE_PROPERTY,
+        QUANTITY_OBSERVABLE_PROPERTY,
+        TEXT_OBSERVABLE_PROPERTY
+    };
+
+    protected static final String[] ALL_OBSERVABLE_PROPERTIES = {
+        COMPOSITE_OBSERVABLE_PROPERTY,
+        BOOLEAN_OBSERVABLE_PROPERTY,
+        CATEGORY_OBSERVABLE_PROPERTY,
+        COUNT_OBSERVABLE_PROPERTY,
+        QUANTITY_OBSERVABLE_PROPERTY,
+        TEXT_OBSERVABLE_PROPERTY
+    };
 
     @Rule
     public final ErrorCollector errors = new ErrorCollector();
@@ -159,20 +118,50 @@ public class ComplexObservationTest extends AbstractComplianceSuiteTest {
     @Before
     public void before() throws OwsExceptionReport {
         activate();
+
         assertThat(pox().entity(createComplexInsertSensorRequest().xmlText(getXmlOptions())).response().asXmlObject(), is(instanceOf(InsertSensorResponseDocument.class)));
         assertThat(pox().entity(createComplexInsertObservationRequest().xmlText(getXmlOptions())).response().asXmlObject(), is(instanceOf(InsertObservationResponseDocument.class)));
-    }
-
-    private void activate() {
-        ServiceOperatorKey sok = new ServiceOperatorKey(SosConstants.SOS, Sos2Constants.SERVICEVERSION);
-        RequestOperatorRepository.getInstance().setActive(new RequestOperatorKey(sok, Sos2Constants.Operations.InsertSensor.name()), true);
-        RequestOperatorRepository.getInstance().setActive(new RequestOperatorKey(sok, SosConstants.Operations.InsertObservation.name()), true);
     }
 
     @After
     public void after() throws OwsExceptionReport {
         H2Configuration.truncate();
         Configurator.getInstance().getCacheController().update();
+    }
+
+    private InsertSensorDocument createComplexInsertSensorRequest() throws OwsExceptionReport {
+        return createInsertSensorRequest(COMPLEX_OBSERVATION_PROCEDURE, COMPLEX_OBSERVATION_OFFERING, COMPOSITE_OBSERVABLE_PROPERTY);
+    }
+
+    private InsertSensorDocument createNumericInsertSensorRequest() throws OwsExceptionReport {
+        return createInsertSensorRequest(NUMERIC_OBSERVATION_PROCEDURE, NUMERIC_OBSERVATION_OFFERING, QUANTITY_OBSERVABLE_PROPERTY);
+    }
+
+    private InsertObservationDocument createComplexInsertObservationRequest() throws OwsExceptionReport {
+        return createComplexInsertObservationRequest(new DateTime());
+    }
+
+    private InsertObservationDocument createComplexInsertObservationRequest(DateTime date) throws OwsExceptionReport {
+        OmObservation observation = createObservation(OmConstants.OBS_TYPE_COMPLEX_OBSERVATION, COMPLEX_OBSERVATION_PROCEDURE, COMPLEX_OBSERVATION_OFFERING,
+                createCompositePhenomenon(), createFeature(FEATURE_OF_INTEREST, createRandomPoint4326()), date, new ComplexValue(createSweDataRecord()));
+        return createInsertObservationRequest(observation, COMPLEX_OBSERVATION_OFFERING);
+    }
+
+    private InsertObservationDocument createNumericInsertObservationRequest() throws OwsExceptionReport {
+        return createNumericInsertObservationRequest(new DateTime());
+    }
+
+    private InsertObservationDocument createNumericInsertObservationRequest(DateTime date) throws OwsExceptionReport {
+        OmObservation observation = createObservation(OmConstants.OBS_TYPE_MEASUREMENT, NUMERIC_OBSERVATION_PROCEDURE, NUMERIC_OBSERVATION_OFFERING,
+                createObservableProperty(QUANTITY_OBSERVABLE_PROPERTY), createFeature(FEATURE_OF_INTEREST, createRandomPoint4326()), date,
+                new QuantityValue(Double.valueOf(42), UNIT));
+        return createInsertObservationRequest(observation, NUMERIC_OBSERVATION_OFFERING);
+    }
+
+    private void activate() {
+        ServiceOperatorKey sok = new ServiceOperatorKey(SosConstants.SOS, Sos2Constants.SERVICEVERSION);
+        RequestOperatorRepository.getInstance().setActive(new RequestOperatorKey(sok, Sos2Constants.Operations.InsertSensor.name()), true);
+        RequestOperatorRepository.getInstance().setActive(new RequestOperatorKey(sok, SosConstants.Operations.InsertObservation.name()), true);
     }
 
     @Test
@@ -196,43 +185,43 @@ public class ComplexObservationTest extends AbstractComplianceSuiteTest {
     @Test
     public void testHiddenParentParentQuery() {
         showChildren(true);
-        checkInvalidObservedProperty(kvp(SosConstants.Operations.GetObservation).query(SosConstants.GetObservationParams.observedProperty, PARENT_OBSERVABLE_PROPERTY).response().asXmlObject());
+        checkInvalidObservedProperty(kvp(SosConstants.Operations.GetObservation).query(SosConstants.GetObservationParams.observedProperty, COMPOSITE_OBSERVABLE_PROPERTY).response().asXmlObject());
     }
 
     @Test
-    public  void testHiddenChildrenChild5Query() {
+    public  void testHiddenChildrenChildBooleanQuery() {
         showChildren(false);
-        checkInvalidObservedProperty(kvp(SosConstants.Operations.GetObservation).query(SosConstants.GetObservationParams.observedProperty, CHILD_OBSERVABLE_PROPERTY_5).response().asXmlObject());
+        checkInvalidObservedProperty(kvp(SosConstants.Operations.GetObservation).query(SosConstants.GetObservationParams.observedProperty, BOOLEAN_OBSERVABLE_PROPERTY).response().asXmlObject());
     }
 
     @Test
-    public  void testHiddenChildrenChild4Query() {
+    public  void testHiddenChildrenChildCategoryQuery() {
         showChildren(false);
-        checkInvalidObservedProperty(kvp(SosConstants.Operations.GetObservation).query(SosConstants.GetObservationParams.observedProperty, CHILD_OBSERVABLE_PROPERTY_4).response().asXmlObject());
+        checkInvalidObservedProperty(kvp(SosConstants.Operations.GetObservation).query(SosConstants.GetObservationParams.observedProperty, CATEGORY_OBSERVABLE_PROPERTY).response().asXmlObject());
     }
 
     @Test
-    public void testHiddenChildrenChild3Query() {
+    public void testHiddenChildrenChildCountQuery() {
         showChildren(false);
-        checkInvalidObservedProperty(kvp(SosConstants.Operations.GetObservation).query(SosConstants.GetObservationParams.observedProperty, CHILD_OBSERVABLE_PROPERTY_3).response().asXmlObject());
+        checkInvalidObservedProperty(kvp(SosConstants.Operations.GetObservation).query(SosConstants.GetObservationParams.observedProperty, COUNT_OBSERVABLE_PROPERTY).response().asXmlObject());
     }
 
     @Test
-    public void testHiddenChildrenChild2Query() {
+    public void testHiddenChildrenChildQuantityQuery() {
         showChildren(false);
-        checkInvalidObservedProperty(kvp(SosConstants.Operations.GetObservation).query(SosConstants.GetObservationParams.observedProperty, CHILD_OBSERVABLE_PROPERTY_2).response().asXmlObject());
+        checkInvalidObservedProperty(kvp(SosConstants.Operations.GetObservation).query(SosConstants.GetObservationParams.observedProperty, QUANTITY_OBSERVABLE_PROPERTY).response().asXmlObject());
     }
 
     @Test
-    public void testHiddenChildrenChild1Query() {
+    public void testHiddenChildrenChildTextQuery() {
         showChildren(false);
-        checkInvalidObservedProperty(kvp(SosConstants.Operations.GetObservation).query(SosConstants.GetObservationParams.observedProperty, CHILD_OBSERVABLE_PROPERTY_1).response().asXmlObject());
+        checkInvalidObservedProperty(kvp(SosConstants.Operations.GetObservation).query(SosConstants.GetObservationParams.observedProperty, TEXT_OBSERVABLE_PROPERTY).response().asXmlObject());
     }
 
     @Test
     public void testHiddenChildrenParentQuery() {
         showChildren(false);
-        checkSingleParentObservation(kvp(SosConstants.Operations.GetObservation).query(SosConstants.GetObservationParams.observedProperty, PARENT_OBSERVABLE_PROPERTY).response().asXmlObject());
+        checkSingleParentObservation(kvp(SosConstants.Operations.GetObservation).query(SosConstants.GetObservationParams.observedProperty, COMPOSITE_OBSERVABLE_PROPERTY).response().asXmlObject());
     }
 
     @Test
@@ -321,19 +310,19 @@ public class ComplexObservationTest extends AbstractComplianceSuiteTest {
         GetObservationResponseDocument document = (GetObservationResponseDocument) getObservationResponse;
         Node node = getObservationResponse.getDomNode();
         errors.checkThat(document.getGetObservationResponse().getObservationDataArray(), arrayWithSize(1));
-        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:observedProperty/@xlink:href", NS_CTX, is(PARENT_OBSERVABLE_PROPERTY)));
-        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:featureOfInterest/@xlink:href", NS_CTX, is(FEATURE_OF_INTEREST)));
+        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:observedProperty/@xlink:href", NS_CTX, is(COMPOSITE_OBSERVABLE_PROPERTY)));
+        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:featureOfInterest/sams:SF_SpatialSamplingFeature/gml:identifier", NS_CTX, is(FEATURE_OF_INTEREST)));
         errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:procedure/@xlink:href", NS_CTX, is(COMPLEX_OBSERVATION_PROCEDURE)));
-        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Quantity/@definition", NS_CTX, is(CHILD_OBSERVABLE_PROPERTY_1)));
+        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Quantity/@definition", NS_CTX, is(QUANTITY_OBSERVABLE_PROPERTY)));
         errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Quantity/swe:value", NS_CTX, is("42.0")));
         errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Quantity/swe:uom/@code", NS_CTX, is(UNIT)));
-        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Boolean/@definition", NS_CTX, is(CHILD_OBSERVABLE_PROPERTY_2)));
+        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Boolean/@definition", NS_CTX, is(BOOLEAN_OBSERVABLE_PROPERTY)));
         errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Boolean/swe:value", NS_CTX, is("true")));
-        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Count/@definition", NS_CTX, is(CHILD_OBSERVABLE_PROPERTY_3)));
+        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Count/@definition", NS_CTX, is(COUNT_OBSERVABLE_PROPERTY)));
         errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Count/swe:value", NS_CTX, is("42")));
-        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Text/@definition", NS_CTX, is(CHILD_OBSERVABLE_PROPERTY_4)));
+        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Text/@definition", NS_CTX, is(TEXT_OBSERVABLE_PROPERTY)));
         errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Text/swe:value", NS_CTX, is("42")));
-        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Category/@definition", NS_CTX, is(CHILD_OBSERVABLE_PROPERTY_5)));
+        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Category/@definition", NS_CTX, is(CATEGORY_OBSERVABLE_PROPERTY)));
         errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Category/swe:value", NS_CTX, is("52")));
         errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result/swe:DataRecord/swe:field/swe:Category/swe:codeSpace/@xlink:href", NS_CTX, is(CODESPACE)));
     }
@@ -346,15 +335,15 @@ public class ComplexObservationTest extends AbstractComplianceSuiteTest {
         errors.checkThat(document.getGetObservationResponse().getObservationDataArray(), arrayWithSize(5));
         errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result[@xsi:type=\"ns:MeasureType\"]", NS_CTX, is("42.0")));
         errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result[@xsi:type=\"ns:MeasureType\"]/@uom", NS_CTX, is(UNIT)));
-        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result[@xsi:type=\"ns:MeasureType\"]/../om:observedProperty/@xlink:href", NS_CTX, is(CHILD_OBSERVABLE_PROPERTY_1)));
+        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result[@xsi:type=\"ns:MeasureType\"]/../om:observedProperty/@xlink:href", NS_CTX, is(QUANTITY_OBSERVABLE_PROPERTY)));
         errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result[@xsi:type=\"xs:boolean\"]", NS_CTX, is("true")));
-        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result[@xsi:type=\"xs:boolean\"]/../om:observedProperty/@xlink:href", NS_CTX, is(CHILD_OBSERVABLE_PROPERTY_2)));
+        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result[@xsi:type=\"xs:boolean\"]/../om:observedProperty/@xlink:href", NS_CTX, is(BOOLEAN_OBSERVABLE_PROPERTY)));
         errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result[@xsi:type=\"xs:integer\"]", NS_CTX, is("42")));
-        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result[@xsi:type=\"xs:integer\"]/../om:observedProperty/@xlink:href", NS_CTX, is(CHILD_OBSERVABLE_PROPERTY_3)));
+        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result[@xsi:type=\"xs:integer\"]/../om:observedProperty/@xlink:href", NS_CTX, is(COUNT_OBSERVABLE_PROPERTY)));
         errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result[@xsi:type=\"xs:string\"]", NS_CTX, is("42")));
-        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result[@xsi:type=\"xs:string\"]/../om:observedProperty/@xlink:href", NS_CTX, is(CHILD_OBSERVABLE_PROPERTY_4)));
+        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result[@xsi:type=\"xs:string\"]/../om:observedProperty/@xlink:href", NS_CTX, is(TEXT_OBSERVABLE_PROPERTY)));
         errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result[@xsi:type=\"ns:ReferenceType\"]/@xlink:title", NS_CTX, is("52")));
-        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result[@xsi:type=\"ns:ReferenceType\"]/../om:observedProperty/@xlink:href", NS_CTX, is(CHILD_OBSERVABLE_PROPERTY_5)));
+        errors.checkThat(node, hasXPath("/sos:GetObservationResponse/sos:observationData/om:OM_Observation/om:result[@xsi:type=\"ns:ReferenceType\"]/../om:observedProperty/@xlink:href", NS_CTX, is(CATEGORY_OBSERVABLE_PROPERTY)));
     }
 
     private void checkInvalidObservedProperty(XmlObject response) {
@@ -365,145 +354,8 @@ public class ComplexObservationTest extends AbstractComplianceSuiteTest {
         errors.checkThat(node, hasXPath("/ows:ExceptionReport/ows:Exception/@locator", NS_CTX, is(SosConstants.GetObservationParams.observedProperty.toString())));
     }
 
-    protected Client pox() {
-        return getExecutor().pox()
-                .contentType(APPLICATION_XML)
-                .accept(APPLICATION_XML);
-    }
-
-    protected Client kvp(Enum<?> operation) {
-        return getExecutor().kvp()
-                .accept(APPLICATION_XML)
-                .query(OWSConstants.RequestParams.service, SosConstants.SOS)
-                .query(OWSConstants.RequestParams.version, Sos2Constants.SERVICEVERSION)
-                .query(OWSConstants.RequestParams.request, operation);
-    }
-
-
-    private InsertSensorDocument createComplexInsertSensorRequest() throws OwsExceptionReport {
-        return createInsertSensorRequest(createComplexObservationProcedure());
-    }
-
-    private InsertSensorDocument createNumericInsertSensorRequest() throws OwsExceptionReport {
-        return createInsertSensorRequest(createNumericObservationProcedure());
-    }
-
-    private SensorML createComplexObservationProcedure() {
-        return createProcedure(COMPLEX_OBSERVATION_PROCEDURE, COMPLEX_OBSERVATION_OFFERING);
-    }
-
-    private SensorML createNumericObservationProcedure() {
-        return createProcedure(NUMERIC_OBSERVATION_PROCEDURE, NUMERIC_OBSERVATION_OFFERING);
-    }
-
-    protected InsertSensorDocument createInsertSensorRequest(SensorML procedure) throws OwsExceptionReport {
-        InsertSensorDocument document = InsertSensorDocument.Factory.newInstance();
-        InsertSensorType insertSensor = document.addNewInsertSensor();
-        insertSensor.setService(SosConstants.SOS);
-        insertSensor.setVersion(Sos2Constants.SERVICEVERSION);
-        insertSensor.addObservableProperty(PARENT_OBSERVABLE_PROPERTY);
-        insertSensor.setProcedureDescriptionFormat(SensorMLConstants.NS_SML);
-        insertSensor.addNewMetadata().addNewInsertionMetadata().set(createSensorInsertionMetadata());
-        insertSensor.addNewProcedureDescription().set(CodingHelper.encodeObjectToXml(SensorMLConstants.NS_SML, procedure));
-        return document;
-    }
-
-    private SosInsertionMetadataType createSensorInsertionMetadata() {
-        SosInsertionMetadataType sosInsertionMetadata = SosInsertionMetadataType.Factory.newInstance();
-        sosInsertionMetadata.addFeatureOfInterestType(OGCConstants.UNKNOWN);
-        sosInsertionMetadata.addFeatureOfInterestType(SfConstants.SAMPLING_FEAT_TYPE_SF_SAMPLING_POINT);
-        for (String observationType : OmConstants.OBSERVATION_TYPES) {
-            sosInsertionMetadata.addObservationType(observationType);
-        }
-        return sosInsertionMetadata;
-    }
-
-    protected SensorML createProcedure(String procedure, String offering) {
-        SensorML wrapper = new SensorML();
-        org.n52.sos.ogc.sensorML.System sensorML = new org.n52.sos.ogc.sensorML.System();
-        wrapper.addMember(sensorML);
-        sensorML.addIdentifier(new SmlIdentifier(UNIQUE_ID_NAME, OGCConstants.URN_UNIQUE_IDENTIFIER, procedure));
-        sensorML.addCapabilities(createOfferingCapabilities(offering));
-        sensorML.addPhenomenon(createCompositePhenomenon());
-        wrapper.setIdentifier(new CodeWithAuthority(procedure, CODESPACE));
-        return wrapper;
-    }
-
-    private SmlCapabilities createOfferingCapabilities(String offering) {
-        return new SmlCapabilities(OFFERING_CAPABILITIES_NAME, new SweSimpleDataRecord().addField(createOfferingField(offering)));
-    }
-
-    private SweField createOfferingField(String offering) {
-        return new SweField(offering, new SweText().setValue(offering).setDefinition(OGCConstants.URN_OFFERING_ID));
-    }
-
-    protected InsertObservationDocument createComplexInsertObservationRequest() throws OwsExceptionReport {
-        return createComplexInsertObservationRequest(DateTime.now());
-    }
-
-    protected InsertObservationDocument createComplexInsertObservationRequest(DateTime time) throws OwsExceptionReport {
-        return createInsertObservationRequest(createComplexObservation(time), COMPLEX_OBSERVATION_OFFERING);
-    }
-
-    protected InsertObservationDocument createNumericInsertObservationRequest() throws OwsExceptionReport {
-        return createNumericInsertObservationRequest(DateTime.now());
-    }
-
-    protected InsertObservationDocument createNumericInsertObservationRequest(DateTime time) throws OwsExceptionReport {
-        return createInsertObservationRequest(createNumericObservation(time), NUMERIC_OBSERVATION_OFFERING);
-    }
-
-    protected InsertObservationDocument createInsertObservationRequest(OmObservation observation, String offering) throws OwsExceptionReport {
-        InsertObservationDocument document = InsertObservationDocument.Factory.newInstance();
-        InsertObservationType insertObservation = document.addNewInsertObservation();
-        insertObservation.setService(SosConstants.SOS);
-        insertObservation.setVersion(Sos2Constants.SERVICEVERSION);
-        insertObservation.addNewOffering().setStringValue(offering);
-        insertObservation.addNewObservation().addNewOMObservation().set(CodingHelper
-                .encodeObjectToXml(OmConstants.NS_OM_2, observation));
-        return document;
-    }
-
-    public OmObservation createComplexObservation(DateTime time) {
-
-        TimeInstant resultTime = new TimeInstant(time);
-        TimeInstant phenomenonTime = new TimeInstant(time);
-        TimePeriod validTime = new TimePeriod(time.minusMinutes(5), time.plusMinutes(5));
-
-        OmObservation observation = new OmObservation();
-        observation.setObservationConstellation(createObservationConstellation(COMPLEX_OBSERVATION_PROCEDURE, COMPLEX_OBSERVATION_OFFERING, OmConstants.OBS_TYPE_COMPLEX_OBSERVATION, createCompositePhenomenon()));
-        observation.setResultTime(resultTime);
-        observation.setValidTime(validTime);
-        observation.setValue(new SingleObservationValue<>(phenomenonTime, new ComplexValue(createSweDataRecord())));
-
-        return observation;
-    }
-
-    private OmObservation createNumericObservation(DateTime time) {
-        TimeInstant resultTime = new TimeInstant(time);
-        TimeInstant phenomenonTime = new TimeInstant(time);
-        TimePeriod validTime = new TimePeriod(time.minusMinutes(5), time.plusMinutes(5));
-
-        OmObservation observation = new OmObservation();
-        observation.setObservationConstellation(createObservationConstellation(NUMERIC_OBSERVATION_PROCEDURE, NUMERIC_OBSERVATION_OFFERING, OmConstants.OBS_TYPE_MEASUREMENT, createObservableProperty()));
-        observation.setResultTime(resultTime);
-        observation.setValidTime(validTime);
-        observation.setValue(new SingleObservationValue<>(phenomenonTime, new QuantityValue(Double.valueOf(42), UNIT)));
-
-        return observation;
-    }
-
-    private OmObservationConstellation createObservationConstellation(String procedure, String offering, String observationType, AbstractPhenomenon observableProperty) {
-        OmObservationConstellation observationConstellation = new OmObservationConstellation();
-        observationConstellation.setFeatureOfInterest(createFeature());
-        observationConstellation.setObservableProperty(observableProperty);
-        observationConstellation.setObservationType(observationType);
-        observationConstellation.setProcedure(createProcedure(procedure, offering));
-        return observationConstellation;
-    }
-
-    private SamplingFeature createFeature() {
-        return new SamplingFeature(new CodeWithAuthority(FEATURE_OF_INTEREST));
+    private static void showChildren(boolean show) {
+        changeSetting(ServiceSettings.EXPOSE_CHILD_OBSERVABLE_PROPERTIES, Boolean.toString(show));
     }
 
     private SweDataRecord createSweDataRecord() {
@@ -518,99 +370,48 @@ public class ComplexObservationTest extends AbstractComplianceSuiteTest {
 
     private SweField createSweCategoryField() {
         SweCategory sweCategory = new SweCategory();
-        sweCategory.setDefinition(CHILD_OBSERVABLE_PROPERTY_5);
+        sweCategory.setDefinition(CATEGORY_OBSERVABLE_PROPERTY);
         sweCategory.setCodeSpace(CODESPACE);
         sweCategory.setValue("52");
-        return new SweField("child5", sweCategory);
+        return new SweField("category", sweCategory);
     }
 
     private SweField createSweTextField() {
         SweText sweText = new SweText();
-        sweText.setDefinition(CHILD_OBSERVABLE_PROPERTY_4);
+        sweText.setDefinition(TEXT_OBSERVABLE_PROPERTY);
         sweText.setValue("42");
-        return new SweField("child4", sweText);
+        return new SweField("text", sweText);
     }
 
     private SweField createSweCountField() {
         SweCount sweCount = new SweCount();
-        sweCount.setDefinition(CHILD_OBSERVABLE_PROPERTY_3);
+        sweCount.setDefinition(COUNT_OBSERVABLE_PROPERTY);
         sweCount.setValue(42);
-        return new SweField("child3", sweCount);
+        return new SweField("count", sweCount);
     }
 
     private SweField createSweBooleanField() {
         SweBoolean sweBoolean = new SweBoolean();
         sweBoolean.setValue(Boolean.TRUE);
-        sweBoolean.setDefinition(CHILD_OBSERVABLE_PROPERTY_2);
-        return new SweField("child2", sweBoolean);
+        sweBoolean.setDefinition(BOOLEAN_OBSERVABLE_PROPERTY);
+        return new SweField("boolean", sweBoolean);
     }
 
     private SweField createSweQuantityField() {
         SweQuantity sweQuantity = new SweQuantity();
-        sweQuantity.setDefinition(CHILD_OBSERVABLE_PROPERTY_1);
+        sweQuantity.setDefinition(QUANTITY_OBSERVABLE_PROPERTY);
         sweQuantity.setUom(UNIT);
         sweQuantity.setValue(42.0);
-        return new SweField("child1", sweQuantity);
+        return new SweField("quantity", sweQuantity);
     }
 
     protected OmCompositePhenomenon createCompositePhenomenon() {
-        OmCompositePhenomenon observableProperty = new OmCompositePhenomenon(PARENT_OBSERVABLE_PROPERTY);
-        observableProperty.addPhenomenonComponent(new OmObservableProperty(CHILD_OBSERVABLE_PROPERTY_1));
-        observableProperty.addPhenomenonComponent(new OmObservableProperty(CHILD_OBSERVABLE_PROPERTY_2));
-        observableProperty.addPhenomenonComponent(new OmObservableProperty(CHILD_OBSERVABLE_PROPERTY_3));
-        observableProperty.addPhenomenonComponent(new OmObservableProperty(CHILD_OBSERVABLE_PROPERTY_4));
-        return observableProperty;
-    }
-    protected OmObservableProperty createObservableProperty() {
-        return new OmObservableProperty(PARENT_OBSERVABLE_PROPERTY);
-    }
-
-    private static void showChildren(boolean show) {
-        changeSetting(ServiceSettings.EXPOSE_CHILD_OBSERVABLE_PROPERTIES, Boolean.toString(show));
-    }
-
-    private static void changeSetting(String setting, String value) {
-        SettingsManager sm = SettingsManager.getInstance();
-        SettingValueFactory sf = sm.getSettingFactory();
-        SettingDefinition<?, ?> sd = sm.getDefinitionByKey(setting);
-        SettingValue<?> sv = sf.newSettingValue(sd, value);
-        try {
-            sm.changeSetting(sv);
-        } catch (ConfigurationException |
-                 ConnectionProviderException ex) {
-            throw new RuntimeException(ex);
-        }
-    }
-
-    protected static XmlOptions getXmlOptions() {
-        return XmlOptionsHelper.getInstance().getXmlOptions();
-    }
-
-    private static class NamespaceContextImpl implements NamespaceContext {
-        private final ImmutableBiMap<String, String> map = ImmutableBiMap
-                .<String, String>builder()
-                .put(Sos2Constants.NS_SOS_PREFIX, Sos2Constants.NS_SOS_20)
-                .put(OWSConstants.NS_OWS_PREFIX, OWSConstants.NS_OWS)
-                .put(SweConstants.NS_SWE_PREFIX, SweConstants.NS_SWE_20)
-                .put(OmConstants.NS_OM_PREFIX, OmConstants.NS_OM_2)
-                .put(W3CConstants.NS_XSI_PREFIX, W3CConstants.NS_XSI)
-                .put(W3CConstants.NS_XLINK_PREFIX, W3CConstants.NS_XLINK)
-                .put(GmlConstants.NS_GML_PREFIX, GmlConstants.NS_GML_32)
-                .build();
-
-        @Override
-        public String getNamespaceURI(String prefix) {
-            return map.get(prefix);
-        }
-
-        @Override
-        public String getPrefix(String namespaceURI) {
-            return map.inverse().get(namespaceURI);
-        }
-
-        @Override
-        public Iterator<String> getPrefixes(String namespaceURI) {
-            return Iterators.singletonIterator(getPrefix(namespaceURI));
-        }
+        OmCompositePhenomenon compositePhenomenon = new OmCompositePhenomenon(COMPOSITE_OBSERVABLE_PROPERTY);
+        compositePhenomenon.addPhenomenonComponent(new OmObservableProperty(BOOLEAN_OBSERVABLE_PROPERTY));
+        compositePhenomenon.addPhenomenonComponent(new OmObservableProperty(CATEGORY_OBSERVABLE_PROPERTY));
+        compositePhenomenon.addPhenomenonComponent(new OmObservableProperty(COUNT_OBSERVABLE_PROPERTY));
+        compositePhenomenon.addPhenomenonComponent(new OmObservableProperty(QUANTITY_OBSERVABLE_PROPERTY));
+        compositePhenomenon.addPhenomenonComponent(new OmObservableProperty(TEXT_OBSERVABLE_PROPERTY));
+        return compositePhenomenon;
     }
 }

--- a/webapp/src/test/java/org/n52/sos/service/it/functional/ObservationEncodingsTest.java
+++ b/webapp/src/test/java/org/n52/sos/service/it/functional/ObservationEncodingsTest.java
@@ -1,0 +1,287 @@
+/**
+ * Copyright (C) 2012-2016 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *     - Apache License, version 2.0
+ *     - Apache Software License, version 1.0
+ *     - GNU Lesser General Public License, version 3
+ *     - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *     - Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public
+ * License version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ */
+package org.n52.sos.service.it.functional;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.zip.ZipInputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.xmlbeans.XmlObject;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ErrorCollector;
+import org.n52.sos.ds.hibernate.H2Configuration;
+import org.n52.sos.netcdf.NetcdfConstants;
+import org.n52.sos.ogc.om.OmConstants;
+import org.n52.sos.ogc.om.OmObservation;
+import org.n52.sos.ogc.om.values.QuantityValue;
+import org.n52.sos.ogc.ows.OWSConstants;
+import org.n52.sos.ogc.ows.OwsExceptionReport;
+import org.n52.sos.ogc.sos.Sos1Constants;
+import org.n52.sos.ogc.sos.Sos2Constants;
+import org.n52.sos.ogc.sos.SosConstants;
+import org.n52.sos.ogc.wml.WaterMLConstants;
+import org.n52.sos.request.operator.RequestOperatorKey;
+import org.n52.sos.request.operator.RequestOperatorRepository;
+import org.n52.sos.service.Configurator;
+import org.n52.sos.service.it.Response;
+import org.n52.sos.service.operator.ServiceOperatorKey;
+import org.n52.sos.util.http.MediaTypes;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import com.sun.jna.Native;
+
+import net.opengis.om.x10.ObservationCollectionDocument;
+import net.opengis.ows.x11.ExceptionReportDocument;
+import net.opengis.sos.x20.GetObservationResponseDocument;
+import net.opengis.sos.x20.InsertObservationResponseDocument;
+import net.opengis.swes.x20.InsertSensorResponseDocument;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.jni.netcdf.Nc4prototypes;
+
+public class ObservationEncodingsTest extends AbstractObservationTest {
+    private static final String FEATURE_OF_INTEREST = "featureOfInterest";
+    private static final String PROCEDURE = "procedure";
+    private static final String OFFERING = "offering";
+    private static final String OBSERVABLE_PROPERTY = "http://example.tld/phenomenon/quantity";
+    private static final String UNIT = "unit";
+
+    @Rule
+    public final ErrorCollector errors = new ErrorCollector();
+
+    @Before
+    public void before() throws OwsExceptionReport {
+        ServiceOperatorKey sok = new ServiceOperatorKey(SosConstants.SOS, Sos2Constants.SERVICEVERSION);
+        RequestOperatorRepository.getInstance().setActive(new RequestOperatorKey(sok, Sos2Constants.Operations.InsertSensor.name()), true);
+        RequestOperatorRepository.getInstance().setActive(new RequestOperatorKey(sok, SosConstants.Operations.InsertObservation.name()), true);
+
+        assertThat(pox().entity(createInsertSensorRequest(PROCEDURE, OFFERING, OBSERVABLE_PROPERTY).xmlText(getXmlOptions())).response().asXmlObject(),
+                is(instanceOf(InsertSensorResponseDocument.class)));
+
+        //create 20 observations to insert
+        List<OmObservation> observations = Lists.newArrayList();
+        for (int i = 0; i < 20; i++) {
+            observations.add(createObservation(OmConstants.OBS_TYPE_MEASUREMENT, PROCEDURE, OFFERING,
+                    createObservableProperty(OBSERVABLE_PROPERTY), createFeature(FEATURE_OF_INTEREST, createRandomPoint4326()),
+                    new DateTime(DateTimeZone.UTC).minusHours(i), new QuantityValue(Math.random() * 10 + 50, UNIT)));
+        }
+
+        assertThat(pox().entity(createInsertObservationRequest(observations, OFFERING).xmlText(getXmlOptions())).response().asXmlObject(),
+                is(instanceOf(InsertObservationResponseDocument.class)));
+    }
+
+    @After
+    public void after() throws OwsExceptionReport {
+        H2Configuration.truncate();
+        Configurator.getInstance().getCacheController().update();
+    }
+
+    @Test
+    public void testSos2GetObsOm2Url() throws IOException {
+        testGetObsXmlResponse(Sos2Constants.SERVICEVERSION, OmConstants.NS_OM_2.toString(),
+                GetObservationResponseDocument.class);
+    }
+
+    @Test
+    public void testSos1GetObsOm1MimeType() throws IOException {
+        testGetObsXmlResponse(Sos1Constants.SERVICEVERSION, OmConstants.CONTENT_TYPE_OM.toString(),
+                ObservationCollectionDocument.class);
+    }
+
+    @Test
+    public void testSos2GetObsWmlUrl() throws IOException {
+        testGetObsXmlResponse(Sos2Constants.SERVICEVERSION, WaterMLConstants.NS_WML_20,
+                GetObservationResponseDocument.class);
+    }
+
+    @Test
+    public void testSos2GetObsWmlDrUrl() throws IOException {
+        testGetObsXmlResponse(Sos2Constants.SERVICEVERSION, WaterMLConstants.NS_WML_20_DR,
+                GetObservationResponseDocument.class);
+    }
+
+    @Test
+    public void testSos1GetObsWmlMimeType() throws IOException {
+        // WML not implemented for SOS 1.0.0, expect an ExceptionDocument
+        testGetObsXmlResponse(Sos1Constants.SERVICEVERSION, WaterMLConstants.WML_CONTENT_TYPE.toString(),
+                ExceptionReportDocument.class);
+    }
+
+    @Test
+    public void testSos1GetObsWmlDrMimeType() throws IOException {
+        // WML not implemented for SOS 1.0.0, expect an ExceptionDocument
+        testGetObsXmlResponse(Sos1Constants.SERVICEVERSION, WaterMLConstants.WML_DR_CONTENT_TYPE.toString(),
+                ExceptionReportDocument.class);
+    }
+
+    @Test
+    public void testSos2GetObsJson() throws IOException {
+        testGetObsJson(Sos2Constants.SERVICEVERSION);
+    }
+
+    @Test
+    public void testSos1GetObsJson() throws IOException {
+        // json not implemented for SOS 1.0.0, expect an ExceptionDocument
+        testGetObsXmlResponse(Sos1Constants.SERVICEVERSION, MediaTypes.APPLICATION_JSON.toString(),
+                ExceptionReportDocument.class);
+    }
+
+    private void testGetObsJson(String serviceVersion) throws IOException {
+        InputStream responseStream = sendGetObsKvp(serviceVersion, MediaTypes.APPLICATION_JSON.toString())
+                .asInputStream();
+        JsonNode json = new ObjectMapper().readTree(responseStream);
+        assertThat(json, notNullValue());
+    }
+
+    @Test
+    public void testSos2GetObsNetcdf() throws IOException {
+        testGetObsNetcdf(Sos2Constants.SERVICEVERSION, NetcdfConstants.CONTENT_TYPE_NETCDF.toString(), false);
+    }
+
+    @Test
+    public void testSos1GetObsNetcdf() throws IOException {
+        testGetObsNetcdf(Sos1Constants.SERVICEVERSION, NetcdfConstants.CONTENT_TYPE_NETCDF.toString(), false);
+    }
+
+    @Test
+    public void testSos2GetObsNetcdfZip() throws IOException {
+        testGetObsNetcdf(Sos2Constants.SERVICEVERSION, NetcdfConstants.CONTENT_TYPE_NETCDF_ZIP.toString(), true);
+    }
+
+    @Test
+    public void testSos1GetObsNetcdfZip() throws IOException {
+        testGetObsNetcdf(Sos1Constants.SERVICEVERSION, NetcdfConstants.CONTENT_TYPE_NETCDF_ZIP.toString(), true);
+    }
+
+    @Test
+    public void testSos2GetObsNetcdf3() throws IOException {
+        testGetObsNetcdf(Sos2Constants.SERVICEVERSION, NetcdfConstants.CONTENT_TYPE_NETCDF_3.toString(), false);
+    }
+
+    @Test
+    public void testSos1GetObsNetcdf3() throws IOException {
+        testGetObsNetcdf(Sos1Constants.SERVICEVERSION, NetcdfConstants.CONTENT_TYPE_NETCDF_3.toString(), false);
+    }
+
+    @Test
+    public void testSos2GetObsNetcdf3Zip() throws IOException {
+        testGetObsNetcdf(Sos2Constants.SERVICEVERSION, NetcdfConstants.CONTENT_TYPE_NETCDF_3_ZIP.toString(), true);
+    }
+
+    @Test
+    public void testSos1GetObsNetcdf3Zip() throws IOException {
+        testGetObsNetcdf(Sos1Constants.SERVICEVERSION, NetcdfConstants.CONTENT_TYPE_NETCDF_3_ZIP.toString(), true);
+    }
+
+    @Test
+    public void testSos2GetObsNetcdf4() throws IOException {
+        testGetObsNetcdf(Sos2Constants.SERVICEVERSION, NetcdfConstants.CONTENT_TYPE_NETCDF_4.toString(), false);
+    }
+
+    @Test
+    public void testSos1GetObsNetcdf4() throws IOException {
+        testGetObsNetcdf(Sos1Constants.SERVICEVERSION, NetcdfConstants.CONTENT_TYPE_NETCDF_4.toString(), false);
+    }
+
+    @Test
+    public void testSos2GetObsNetcdf4Zip() throws IOException {
+        testGetObsNetcdf(Sos2Constants.SERVICEVERSION, NetcdfConstants.CONTENT_TYPE_NETCDF_4_ZIP.toString(), true);
+    }
+
+    @Test
+    public void testSos1GetObsNetcdf4Zip() throws IOException {
+        testGetObsNetcdf(Sos1Constants.SERVICEVERSION, NetcdfConstants.CONTENT_TYPE_NETCDF_4_ZIP.toString(), true);
+    }
+
+    private void testGetObsNetcdf(String serviceVersion, String responseFormat, boolean isZip) throws IOException {
+        // check for netcdf lib before test is run. on debian/ubuntu the package is libnetcdf-dev
+        // TODO shouldn't netcdf3 response formats work without this library?
+        try {
+            Native.loadLibrary("netcdf", Nc4prototypes.class);
+        } catch (UnsatisfiedLinkError e) {
+            Assume.assumeNoException("netcdf library not detected, skipping test", e);
+        }
+
+        InputStream inputStream = sendGetObsKvp(serviceVersion, responseFormat).asInputStream();
+        File netcdfFile = File.createTempFile("52n-sos-netcdf-test", ".nc");
+        FileOutputStream fileOutputStream = new FileOutputStream(netcdfFile);
+        if (isZip) {
+            ZipInputStream zis = new ZipInputStream(inputStream);
+            zis.getNextEntry();
+            IOUtils.copy(zis, fileOutputStream);
+            zis.closeEntry();
+            zis.close();
+        } else {
+            IOUtils.copy(inputStream, fileOutputStream);
+        }
+        fileOutputStream.close();
+        inputStream.close();
+        assertThat(netcdfFile, notNullValue());
+
+        NetcdfDataset netcdfDataset = NetcdfDataset.openDataset(netcdfFile.getAbsolutePath());
+        assertThat(netcdfDataset, notNullValue());
+        netcdfDataset.close();
+        netcdfFile.delete();
+    }
+
+    private void testGetObsXmlResponse(String serviceVersion, String responseFormat, Class<?> expectedResponseClass)
+            throws IOException {
+        XmlObject responseDoc = sendGetObsKvp(serviceVersion, responseFormat).asXmlObject();
+        assertThat(responseDoc, is(instanceOf(expectedResponseClass)));
+    }
+
+    private Response sendGetObsKvp(String serviceVersion, String responseFormat) {
+        return getExecutor().kvp()
+                .query(OWSConstants.RequestParams.service, SosConstants.SOS)
+                .query(OWSConstants.RequestParams.version, serviceVersion)
+                .query(OWSConstants.RequestParams.request, SosConstants.Operations.GetObservation)
+                .query(SosConstants.GetObservationParams.procedure, PROCEDURE)
+                .query(SosConstants.GetObservationParams.offering, OFFERING)
+                .query(SosConstants.GetObservationParams.observedProperty, OBSERVABLE_PROPERTY)
+                .query(SosConstants.GetObservationParams.responseFormat, responseFormat)
+                .response();
+    }
+
+}


### PR DESCRIPTION
This PR:

* Adds an encoder key for SOS 1.0.0 to the `coding-json` `AbstractSosResponseEncoder`
* Factors out reusable methods from `ComplexObservationTest` to an extendable `AbstractObservationTest`
* Adds `ObservationEncodingsTest`, an integration test which inserts a simple sensor and observations and sends test `GetObservation` requests for various service versions and response formats.