### PR TITLE
Fixes #484

### DIFF
--- a/coding/wml-v20/src/main/java/org/n52/sos/encode/WmlTVPEncoderv20.java
+++ b/coding/wml-v20/src/main/java/org/n52/sos/encode/WmlTVPEncoderv20.java
@@ -36,20 +36,10 @@ import java.util.Set;
 
 import javax.xml.stream.XMLStreamException;
 
-import net.opengis.om.x20.OMObservationType;
-import net.opengis.waterml.x20.DefaultTVPMeasurementMetadataDocument;
-import net.opengis.waterml.x20.MeasureTVPType;
-import net.opengis.waterml.x20.MeasurementTimeseriesDocument;
-import net.opengis.waterml.x20.MeasurementTimeseriesMetadataType;
-import net.opengis.waterml.x20.MeasurementTimeseriesType;
-import net.opengis.waterml.x20.TVPDefaultMetadataPropertyType;
-import net.opengis.waterml.x20.TVPMeasurementMetadataType;
-
 import org.apache.xmlbeans.XmlObject;
 import org.n52.sos.encode.streaming.WmlTVPEncoderv20XmlStreamWriter;
 import org.n52.sos.exception.ows.NoApplicableCodeException;
 import org.n52.sos.exception.ows.concrete.UnsupportedEncoderInputException;
-import org.n52.sos.ogc.gml.time.TimeInstant;
 import org.n52.sos.ogc.om.AbstractObservationValue;
 import org.n52.sos.ogc.om.MultiObservationValues;
 import org.n52.sos.ogc.om.ObservationValue;
@@ -78,6 +68,15 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
+
+import net.opengis.om.x20.OMObservationType;
+import net.opengis.waterml.x20.DefaultTVPMeasurementMetadataDocument;
+import net.opengis.waterml.x20.MeasureTVPType;
+import net.opengis.waterml.x20.MeasurementTimeseriesDocument;
+import net.opengis.waterml.x20.MeasurementTimeseriesMetadataType;
+import net.opengis.waterml.x20.MeasurementTimeseriesType;
+import net.opengis.waterml.x20.TVPDefaultMetadataPropertyType;
+import net.opengis.waterml.x20.TVPMeasurementMetadataType;
 
 /**
  * Encoder class for WaterML 2.0 TimeseriesValuePair (TVP)
@@ -234,26 +233,23 @@ public class WmlTVPEncoderv20 extends AbstractWmlEncoderv20 {
         xbDefMeasureMetaComponent.getDefaultTVPMeasurementMetadata().getInterpolationType().setTitle("Instantaneous");
         String unit = null;
         if (sosObservation.getValue() instanceof SingleObservationValue) {
-            // time periods can not be set in MeasureTVPType
-            if (sosObservation.getValue().getPhenomenonTime() instanceof TimeInstant) {
-                SingleObservationValue<?> singleObservationValue =
-                        (SingleObservationValue<?>) sosObservation.getValue();
-                String time = getTimeString(singleObservationValue.getPhenomenonTime());
-                unit = singleObservationValue.getValue().getUnit();
-                if (sosObservation.getValue().getValue() instanceof QuantityValue) {
-                    QuantityValue quantityValue = (QuantityValue) singleObservationValue.getValue();
-                    if (!quantityValue.getValue().equals(Double.NaN)) {
-                        String value = Double.toString(quantityValue.getValue().doubleValue());
-                        addValuesToMeasurementTVP(measurementTimeseries.addNewPoint().addNewMeasurementTVP(), time,
-                                value);
-                    }
-                } else if (sosObservation.getValue().getValue() instanceof CountValue) {
-                    CountValue countValue = (CountValue) singleObservationValue.getValue();
-                    if (countValue.getValue() != null) {
-                        String value = Integer.toString(countValue.getValue().intValue());
-                        addValuesToMeasurementTVP(measurementTimeseries.addNewPoint().addNewMeasurementTVP(), time,
-                                value);
-                    }
+            SingleObservationValue<?> singleObservationValue =
+                    (SingleObservationValue<?>) sosObservation.getValue();
+            String time = getTimeString(singleObservationValue.getPhenomenonTime());
+            unit = singleObservationValue.getValue().getUnit();
+            if (sosObservation.getValue().getValue() instanceof QuantityValue) {
+                QuantityValue quantityValue = (QuantityValue) singleObservationValue.getValue();
+                if (!quantityValue.getValue().equals(Double.NaN)) {
+                    String value = Double.toString(quantityValue.getValue().doubleValue());
+                    addValuesToMeasurementTVP(measurementTimeseries.addNewPoint().addNewMeasurementTVP(), time,
+                            value);
+                }
+            } else if (sosObservation.getValue().getValue() instanceof CountValue) {
+                CountValue countValue = (CountValue) singleObservationValue.getValue();
+                if (countValue.getValue() != null) {
+                    String value = Integer.toString(countValue.getValue().intValue());
+                    addValuesToMeasurementTVP(measurementTimeseries.addNewPoint().addNewMeasurementTVP(), time,
+                            value);
                 }
             }
         } else if (sosObservation.getValue() instanceof MultiObservationValues) {
@@ -262,25 +258,21 @@ public class WmlTVPEncoderv20 extends AbstractWmlEncoderv20 {
             List<TimeValuePair> timeValuePairs = tvpValue.getValue();
             unit = tvpValue.getUnit();
             for (TimeValuePair timeValuePair : timeValuePairs) {
-                // time periods can not be set in MeasureTVPType
-                if (timeValuePair.getTime() instanceof TimeInstant) {
-                    if (timeValuePair.getValue() instanceof QuantityValue) {
-                        QuantityValue quantityValue = (QuantityValue) timeValuePair.getValue();
-                        if (!quantityValue.getValue().equals(Double.NaN)) {
-                            timeValuePair.getTime();
-                            String time = getTimeString(timeValuePair.getTime());
-                            String value = Double.toString(quantityValue.getValue().doubleValue());
-                            addValuesToMeasurementTVP(measurementTimeseries.addNewPoint().addNewMeasurementTVP(), time,
-                                    value);
-                        }
-                    } else if (timeValuePair.getValue() instanceof CountValue) {
-                        CountValue countValue = (CountValue) timeValuePair.getValue();
-                        if (countValue.getValue() != null) {
-                            String time = getTimeString(timeValuePair.getTime());
-                            String value = Integer.toString(countValue.getValue().intValue());
-                            addValuesToMeasurementTVP(measurementTimeseries.addNewPoint().addNewMeasurementTVP(), time,
-                                    value);
-                        }
+                if (timeValuePair.getValue() instanceof QuantityValue) {
+                    QuantityValue quantityValue = (QuantityValue) timeValuePair.getValue();
+                    if (!quantityValue.getValue().equals(Double.NaN)) {
+                        String time = getTimeString(timeValuePair.getTime());
+                        String value = Double.toString(quantityValue.getValue().doubleValue());
+                        addValuesToMeasurementTVP(measurementTimeseries.addNewPoint().addNewMeasurementTVP(), time,
+                                value);
+                    }
+                } else if (timeValuePair.getValue() instanceof CountValue) {
+                    CountValue countValue = (CountValue) timeValuePair.getValue();
+                    if (countValue.getValue() != null) {
+                        String time = getTimeString(timeValuePair.getTime());
+                        String value = Integer.toString(countValue.getValue().intValue());
+                        addValuesToMeasurementTVP(measurementTimeseries.addNewPoint().addNewMeasurementTVP(), time,
+                                value);
                     }
                 }
             }


### PR DESCRIPTION
WaterML 2.0 TVP response contains no values if phenomenonTime is a time period

- Remove superfluous instanceOf check for phenomenonTime because the getTimeString() method supports time period and time instant