### PR TITLE
Update EXISettings.java

### DIFF
--- a/coding/exi/src/main/java/org/n52/sos/exi/EXISettings.java
+++ b/coding/exi/src/main/java/org/n52/sos/exi/EXISettings.java
@@ -122,7 +122,7 @@ public class EXISettings implements SettingDefinitionProvider {
 					+ "performance and compression.<ul><li><b>Default"
 					+ "</b>: uses some default options. If any of the other"
 					+ " options is selected, default options is skipped."
-					+ "</li><li><b>Specific</b>: uses the options activated"
+					+ "</li><li><b>Specific</b>: uses the options activated "
 					+ "further down.</li><li><b>Strict</b>: "
 					+ "no namespace prefixes, comments etc are preserved nor"
 					+ " schema deviations are allowed.</li></ul>").


### PR DESCRIPTION
Add missing whitespace. Current version results in "...activatedfurther..." in the WebUI.