### PR TITLE
Fix hidden npe during sample data insertion

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -50,6 +50,7 @@ RELEASE NOTES
         * https://wiki.52north.org/SensorWeb/RegisterBinding
       * Insertion of "up-to-date" example data that can be used by the Helgoland Client
         * The SOS example requests are still for the test data!
+      * Show client IP during installation for transactional security settings
   
   --- Changes ---
   
@@ -93,6 +94,8 @@ RELEASE NOTES
       * Issue #395: Creating database schema fails for MySQL
       * Issue #422: Failed conversion between SML 2.0 and SML 1.0.1
       * Issue #439: quality tag how metadata of output list
+      * Issue #???: Hidden NPE cause by not set request context while inserting new sample data
+                    https://github.com/52North/SOS/pull/543
 
 
     Release 52n-sensorweb-sos-4.3.14

--- a/core/api/src/main/java/org/n52/sos/request/operator/TransactionalRequestChecker.java
+++ b/core/api/src/main/java/org/n52/sos/request/operator/TransactionalRequestChecker.java
@@ -28,8 +28,10 @@
  */
 package org.n52.sos.request.operator;
 
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableSet;
 import java.util.Set;
-
 import org.n52.sos.exception.ows.NoApplicableCodeException;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
 import org.n52.sos.request.RequestContext;
@@ -38,10 +40,6 @@ import org.n52.sos.util.http.HTTPStatus;
 import org.n52.sos.util.net.IPAddress;
 import org.n52.sos.util.net.IPAddressRange;
 import org.n52.sos.util.net.ProxyChain;
-
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.collect.ImmutableSet;
 
 /**
  * TODO JavaDoc
@@ -62,7 +60,13 @@ public class TransactionalRequestChecker {
     }
 
     public void check(RequestContext rc) throws OwsExceptionReport {
-        if (!predicate.apply(rc)) {
+        if (rc == null) {
+            throw new NoApplicableCodeException()
+                    .causedBy(new NullPointerException(
+                            "RequestContext MUST not be null!"))
+                    .setStatus(HTTPStatus.INTERNAL_SERVER_ERROR);
+        }
+        else if (!predicate.apply(rc)) {
             throw new NoApplicableCodeException()
                     .withMessage("Not authorized for transactional operations!")
                     .setStatus(HTTPStatus.UNAUTHORIZED);

--- a/core/api/src/test/java/org/n52/sos/request/operator/TransactionalRequestCheckerTest.java
+++ b/core/api/src/test/java/org/n52/sos/request/operator/TransactionalRequestCheckerTest.java
@@ -28,18 +28,18 @@
  */
 package org.n52.sos.request.operator;
 
-import static org.n52.sos.util.HasStatusCode.hasStatusCode;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.n52.sos.config.SettingsManager;
+import org.n52.sos.exception.ows.NoApplicableCodeException;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
 import org.n52.sos.request.RequestContext;
 import org.n52.sos.service.TransactionalSecurityConfiguration;
-import org.n52.sos.util.net.IPAddress;
+import org.n52.sos.util.HasStatusCode;
 import org.n52.sos.util.http.HTTPStatus;
+import org.n52.sos.util.net.IPAddress;
 
 /**
  * @since 4.0.0
@@ -102,7 +102,7 @@ public class TransactionalRequestCheckerTest {
         tsc.setTransactionalAllowedIps(IP.toString());
         tsc.setTransactionalToken(NULL);
         thrown.expect(OwsExceptionReport.class);
-        thrown.expect(hasStatusCode(HTTPStatus.UNAUTHORIZED));
+        thrown.expect(HasStatusCode.hasStatusCode(HTTPStatus.UNAUTHORIZED));
         new TransactionalRequestChecker(tsc).check(getRequestContextIp(false));
     }
 
@@ -113,7 +113,7 @@ public class TransactionalRequestCheckerTest {
         tsc.setTransactionalAllowedIps(NULL);
         tsc.setTransactionalToken(TOKEN);
         thrown.expect(OwsExceptionReport.class);
-        thrown.expect(hasStatusCode(HTTPStatus.UNAUTHORIZED));
+        thrown.expect(HasStatusCode.hasStatusCode(HTTPStatus.UNAUTHORIZED));
         new TransactionalRequestChecker(tsc).check(getRequestContextToken(false));
     }
 
@@ -124,7 +124,7 @@ public class TransactionalRequestCheckerTest {
         tsc.setTransactionalAllowedIps(IP.toString());
         tsc.setTransactionalToken(TOKEN);
         thrown.expect(OwsExceptionReport.class);
-        thrown.expect(hasStatusCode(HTTPStatus.UNAUTHORIZED));
+        thrown.expect(HasStatusCode.hasStatusCode(HTTPStatus.UNAUTHORIZED));
         new TransactionalRequestChecker(tsc).check(getRequestContextBoth(false, false));
     }
 
@@ -135,7 +135,7 @@ public class TransactionalRequestCheckerTest {
         tsc.setTransactionalAllowedIps(IP.toString());
         tsc.setTransactionalToken(TOKEN);
         thrown.expect(OwsExceptionReport.class);
-        thrown.expect(hasStatusCode(HTTPStatus.UNAUTHORIZED));
+        thrown.expect(HasStatusCode.hasStatusCode(HTTPStatus.UNAUTHORIZED));
         new TransactionalRequestChecker(tsc).check(getRequestContextBoth(true, false));
     }
 
@@ -146,8 +146,15 @@ public class TransactionalRequestCheckerTest {
         tsc.setTransactionalAllowedIps(IP.toString());
         tsc.setTransactionalToken(TOKEN);
         thrown.expect(OwsExceptionReport.class);
-        thrown.expect(hasStatusCode(HTTPStatus.UNAUTHORIZED));
+        thrown.expect(HasStatusCode.hasStatusCode(HTTPStatus.UNAUTHORIZED));
         new TransactionalRequestChecker(tsc).check(getRequestContextBoth(false, true));
+    }
+
+    @Test
+    public void shouldException_MissingRequestContext() throws OwsExceptionReport {
+        thrown.expect(NoApplicableCodeException.class);
+        thrown.expect(HasStatusCode.hasStatusCode(HTTPStatus.INTERNAL_SERVER_ERROR));
+        new TransactionalRequestChecker(tsc).check(null);
     }
 
     private RequestContext getRequestContextIp(boolean validIp) {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     # change to 7- or 9- to change the tomcat version
     image: tomcat:8-jre8-alpine
     ports:
-      - 80:8080
+      - 8080:8080
       - 8000:8000
     links:
       - db:postgres

--- a/hibernate/dao/src/test/java/org/n52/sos/ds/hibernate/InsertDAOTest.java
+++ b/hibernate/dao/src/test/java/org/n52/sos/ds/hibernate/InsertDAOTest.java
@@ -28,11 +28,19 @@
  */
 package org.n52.sos.ds.hibernate;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
+import net.opengis.sensorML.x101.SystemDocument;
+import net.opengis.swe.x20.DataRecordDocument;
+import net.opengis.swe.x20.TextEncodingDocument;
 import org.hibernate.Session;
 import org.joda.time.DateTime;
 import org.junit.After;
@@ -101,6 +109,7 @@ import org.n52.sos.request.InsertObservationRequest;
 import org.n52.sos.request.InsertResultRequest;
 import org.n52.sos.request.InsertResultTemplateRequest;
 import org.n52.sos.request.InsertSensorRequest;
+import org.n52.sos.request.RequestContext;
 import org.n52.sos.request.operator.SosInsertObservationOperatorV20;
 import org.n52.sos.response.DeleteSensorResponse;
 import org.n52.sos.response.GetObservationResponse;
@@ -111,17 +120,6 @@ import org.n52.sos.response.InsertSensorResponse;
 import org.n52.sos.service.Configurator;
 import org.n52.sos.util.CodingHelper;
 import org.n52.sos.util.CollectionHelper;
-
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-
-import net.opengis.sensorML.x101.SystemDocument;
-import net.opengis.swe.x20.DataRecordDocument;
-import net.opengis.swe.x20.TextEncodingDocument;
 
 /**
  * Test various Insert*DAOs using a common set of test data with hierarchical
@@ -611,7 +609,8 @@ public class InsertDAOTest extends HibernateTestCase {
         obsVal.setPhenomenonTime(new TimeInstant(null, TimeIndeterminateValue.template));
         obsVal.setValue(sweDataArrayValue);
         obs.setValue(obsVal);
-        req.setObservation(Lists.newArrayList(obs));
+        req.setObservation(Lists.newArrayList(obs))
+            .setRequestContext(new RequestContext());
         insertObservationOperatorv2.receiveRequest(req);
         assertInsertionAftermathBeforeAndAfterCacheReload();
 

--- a/spring/admin-controller/src/main/java/org/n52/sos/web/admin/AdminDatasourceController.java
+++ b/spring/admin-controller/src/main/java/org/n52/sos/web/admin/AdminDatasourceController.java
@@ -28,6 +28,9 @@
  */
 package org.n52.sos.web.admin;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
@@ -35,12 +38,13 @@ import java.net.URLDecoder;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.ServiceLoader;
-
+import javax.servlet.http.HttpServletRequest;
 import org.apache.xmlbeans.XmlException;
 import org.n52.sos.ds.ConnectionProviderException;
 import org.n52.sos.ds.GeneralQueryDAO;
 import org.n52.sos.exception.MissingServiceOperatorException;
 import org.n52.sos.ogc.ows.OwsExceptionReport;
+import org.n52.sos.request.RequestContext;
 import org.n52.sos.util.JSONUtils;
 import org.n52.sos.web.ControllerConstants;
 import org.slf4j.Logger;
@@ -54,10 +58,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.servlet.ModelAndView;
-
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.Maps;
 
 /**
  * @since 4.0.0
@@ -145,9 +145,16 @@ public class AdminDatasourceController extends AbstractDatasourceController {
     }
     
     @ResponseBody
-    @RequestMapping(value = ControllerConstants.Paths.ADMIN_DATABASE_ADD_SAMPLEDATA, method = RequestMethod.POST)
-    public String addSampledata() throws OwsExceptionReport, ConnectionProviderException, IOException, URISyntaxException, XmlException, MissingServiceOperatorException {
-        boolean sampledataAdded = new SampleDataInserter().insertSampleData();
+    @RequestMapping(
+            value = ControllerConstants.Paths.ADMIN_DATABASE_ADD_SAMPLEDATA,
+            method = RequestMethod.POST)
+    public String addSampledata(HttpServletRequest request) throws OwsExceptionReport,
+            ConnectionProviderException, IOException, URISyntaxException,
+            XmlException, MissingServiceOperatorException {
+
+        boolean sampledataAdded = new SampleDataInserter(
+                RequestContext.fromRequest(request))
+                .insertSampleData();
         if (sampledataAdded) {
             updateCache();
         }

--- a/spring/views/src/main/webapp/WEB-INF/views/install/settings.jsp
+++ b/spring/views/src/main/webapp/WEB-INF/views/install/settings.jsp
@@ -46,6 +46,53 @@
     }
 </script>
 
+<%
+    String ip = request.getHeader("X-Forwarded-For");
+    if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+        ip = request.getHeader("Proxy-Client-IP");
+    }
+    if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+        ip = request.getHeader("WL-Proxy-Client-IP");
+    }
+    if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+        ip = request.getHeader("HTTP_CLIENT_IP");
+    }
+    if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+        ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+    }
+    if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+        ip = request.getRemoteAddr();
+    }
+    pageContext.setAttribute("clientIp", ip);
+%>
+
+<script type="text/javascript">
+    function waitForElementToDisplayAfter(selector, time, content) {
+        if($(selector).length > 0) {
+            $(selector).after(content);
+            return;
+        }
+        else {
+            setTimeout(function() {
+                waitForElementToDisplayAfter(selector, time, content);
+            }, time);
+        }
+    }
+
+    $( document ).ready(function() {
+        waitForElementToDisplayAfter(
+            "#service_transactionalallowedips > div.controls > span.help-block",
+            1000,
+            "<br /><span class='alert alert-info'>" +
+            "Consider entering the IP of our machine: " +
+            "<code>" +
+            "<c:out value="${clientIp}" escapeXml="false"/>" +
+            "</code>" +
+            "</span>"
+        );
+    });
+</script>
+
 <form action="<c:url value="/install/settings" />" method="POST" class="form-horizontal">
 	<div id="settings"></div>
 	<script type="text/javascript">


### PR DESCRIPTION
This PR fixes a hidden NPE in method `org/n52/sos/request/operator/TransactionalRequestChecker.check(...)`.
In addition, a new info message is displayed during installation:
![enter-own-ip-info-message](https://cloud.githubusercontent.com/assets/3839896/25803483/5db21e22-33f7-11e7-9683-97c48f3e7be9.png)
