### PR TITLE
ProcedureDescriptionFormatRepositoryInitializer added

### DIFF
--- a/core/api/src/main/java/org/n52/sos/coding/encode/ProcedureDescriptionFormatRepository.java
+++ b/core/api/src/main/java/org/n52/sos/coding/encode/ProcedureDescriptionFormatRepository.java
@@ -28,7 +28,6 @@
  */
 package org.n52.sos.coding.encode;
 
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -57,9 +56,8 @@ import com.google.common.collect.Sets;
  * @author Christian Autermann
  */
 public class ProcedureDescriptionFormatRepository
-        implements Constructable,
-                   ActivationManager<ProcedureDescriptionFormatKey>,
-                   ActivationSource<ProcedureDescriptionFormatKey> {
+        implements ActivationManager<ProcedureDescriptionFormatKey>,
+        ActivationSource<ProcedureDescriptionFormatKey> {
 
     @Deprecated
     private static ProcedureDescriptionFormatRepository instance;
@@ -71,12 +69,19 @@ public class ProcedureDescriptionFormatRepository
 
     private final Map<String, Map<String, Set<String>>> transactionalProcedureDescriptionFormats = Maps.newHashMap();
 
-    @Override
-    public void init() {
+    /**
+     * This class does not implement {@link Constructable} due to some circular dependencies that can lead to an
+     * incorrect initialization order; instead {@link ProcedureDescriptionFormatRepositoryInitializer} does this for us.
+     *
+     * @param serviceOperatorRepository the service operator respository
+     * @param encoderRepository         the encoder repository
+     */
+    public void init(ServiceOperatorRepository serviceOperatorRepository,
+              EncoderRepository encoderRepository) {
         ProcedureDescriptionFormatRepository.instance = this;
 
-        Objects.requireNonNull(this.encoderRepository);
-        Objects.requireNonNull(this.serviceOperatorRepository);
+        this.serviceOperatorRepository = Objects.requireNonNull(serviceOperatorRepository);
+        this.encoderRepository = Objects.requireNonNull(encoderRepository);
 
         generateProcedureDescriptionFormatMaps();
     }

--- a/core/api/src/main/java/org/n52/sos/coding/encode/ProcedureDescriptionFormatRepositoryInitializer.java
+++ b/core/api/src/main/java/org/n52/sos/coding/encode/ProcedureDescriptionFormatRepositoryInitializer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2012-2017 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *     - Apache License, version 2.0
+ *     - Apache Software License, version 1.0
+ *     - GNU Lesser General Public License, version 3
+ *     - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *     - Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public
+ * License version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ */
+package org.n52.sos.coding.encode;
+
+import javax.inject.Inject;
+
+import org.n52.iceland.service.operator.ServiceOperatorRepository;
+import org.n52.janmayen.lifecycle.Constructable;
+import org.n52.svalbard.encode.EncoderRepository;
+
+/**
+ * Separate initializer for {@link ProcedureDescritionFormatRepository}
+ *
+ * @see ProcedureDescritionFormatRepository.init()
+ * @author Martin Kiesow
+ */
+public class ProcedureDescriptionFormatRepositoryInitializer implements Constructable {
+
+    private final EncoderRepository encoderRepository;
+    private final ServiceOperatorRepository serviceOperatorRepository;
+    private final ProcedureDescriptionFormatRepository procedureDescriptionFormatRepository;
+
+    @Inject
+    public ProcedureDescriptionFormatRepositoryInitializer(EncoderRepository encoderRepository,
+                                               ServiceOperatorRepository serviceOperatorRepository,
+                                               ProcedureDescriptionFormatRepository procedureDescriptionFormatRepository) {
+        this.encoderRepository = encoderRepository;
+        this.serviceOperatorRepository = serviceOperatorRepository;
+        this.procedureDescriptionFormatRepository = procedureDescriptionFormatRepository;
+    }
+
+    @Override
+    public void init() {
+        this.procedureDescriptionFormatRepository.init(this.serviceOperatorRepository, this.encoderRepository);
+    }
+
+}

--- a/core/api/src/main/resources/contexts/configured/sos.xml
+++ b/core/api/src/main/resources/contexts/configured/sos.xml
@@ -45,6 +45,9 @@
     <bean id="procedureDescriptionFormatRepository"
           class="org.n52.sos.coding.encode.ProcedureDescriptionFormatRepository" />
 
+    <bean id="procedureDescriptionFormatRepositoryInitializer"
+          class="org.n52.sos.coding.encode.ProcedureDescriptionFormatRepositoryInitializer" />
+
     <bean id="batchRequestOperator"
           class="org.n52.sos.request.operator.BatchRequestOperator"/>
 


### PR DESCRIPTION
InsertSensor Request didn't work on a freshly installed SOS instance. By adding an initializer class, the `ProcedureDescriptionFormatRepository` is not created until the formats are available.