### PR TITLE
Fix npe in delete sensor

### DIFF
--- a/core/api/src/main/java/org/n52/sos/util/CollectionHelper.java
+++ b/core/api/src/main/java/org/n52/sos/util/CollectionHelper.java
@@ -546,6 +546,5 @@ public final class CollectionHelper {
 		}
 		return split;
 	}
-    
 
 }

--- a/core/api/src/main/java/org/n52/sos/util/CollectionHelper.java
+++ b/core/api/src/main/java/org/n52/sos/util/CollectionHelper.java
@@ -55,6 +55,7 @@ import com.google.common.collect.Sets;
  * @since 4.0.0
  */
 public final class CollectionHelper {
+
     private CollectionHelper() {
     }
 

--- a/core/api/src/test/java/org/n52/sos/util/CollectionHelperTest.java
+++ b/core/api/src/test/java/org/n52/sos/util/CollectionHelperTest.java
@@ -153,4 +153,5 @@ public class CollectionHelperTest {
     	assertThat(iterator.next(),is(3));
     	assertThat(iterator.next(),is(4));
     }
+
 }

--- a/core/api/src/test/java/org/n52/sos/util/CollectionHelperTest.java
+++ b/core/api/src/test/java/org/n52/sos/util/CollectionHelperTest.java
@@ -53,7 +53,8 @@ import com.google.common.collect.Sets;
  * 
  */
 public class CollectionHelperTest {
-    private final Set<String> EMPTY_COLLECTION = new HashSet<String>(0);
+
+    private final Set<String> EMPTY_COLLECTION = new HashSet<>(0);
 
     @Test
     public void should_return_empty_list_when_union_receives_null() {
@@ -62,32 +63,32 @@ public class CollectionHelperTest {
 
     @Test
     public void should_return_empty_list_when_unionOfListOfLists_receives_empty_list() {
-        final Collection<? extends Collection<String>> emptyList = new ArrayList<Set<String>>(0);
+        final Collection<? extends Collection<String>> emptyList = new ArrayList<>(0);
         assertThat(unionOfListOfLists(emptyList), is(EMPTY_COLLECTION));
     }
 
     @Test
     public void should_return_union_of_values_without_duplicates() {
-        final Collection<String> listA = new ArrayList<String>(2);
+        final Collection<String> listA = new ArrayList<>(2);
         listA.add("A");
         listA.add("B");
 
-        final Collection<String> listB = new ArrayList<String>(4);
+        final Collection<String> listB = new ArrayList<>(4);
         listB.add("B");
         listB.add("C");
         listB.add(null);
 
-        final Collection<String> listC = new ArrayList<String>(2);
+        final Collection<String> listC = new ArrayList<>(2);
         listC.add("");
 
-        final Collection<Collection<String>> col = new ArrayList<Collection<String>>(4);
+        final Collection<Collection<String>> col = new ArrayList<>(4);
         col.add(listA);
         col.add(listB);
         col.add(listC);
         col.add(null);
         col.add(new ArrayList<String>(0));
 
-        final Collection<String> check = new HashSet<String>(4);
+        final Collection<String> check = new HashSet<>(4);
         check.add("A");
         check.add("B");
         check.add("C");
@@ -97,26 +98,26 @@ public class CollectionHelperTest {
 
     @Test
     public void isNotEmpty_should_return_true_if_map_is_not_empty() {
-        final Map<String, String> map = new HashMap<String, String>(1);
+        final Map<String, String> map = new HashMap<>(1);
         map.put("key", "value");
         assertThat(CollectionHelper.isNotEmpty(map), is(TRUE));
     }
 
     @Test
     public void isNotEmpty_should_return_false_if_map_is_empty() {
-        final Map<String, String> map = new HashMap<String, String>(0);
+        final Map<String, String> map = new HashMap<>(0);
         assertThat(CollectionHelper.isNotEmpty(map), is(FALSE));
     }
 
     @Test
     public void isEmpty_should_return_true_if_map_is_empty() {
-        final Map<String, String> map = new HashMap<String, String>(0);
+        final Map<String, String> map = new HashMap<>(0);
         assertThat(CollectionHelper.isEmpty(map), is(TRUE));
     }
 
     @Test
     public void isEmpty_should_return_false_if_map_is_not_empty() {
-        final Map<String, String> map = new HashMap<String, String>(1);
+        final Map<String, String> map = new HashMap<>(1);
         map.put("key", "value");
         assertThat(CollectionHelper.isEmpty(map), is(FALSE));
     }

--- a/core/cache/src/main/java/org/n52/sos/cache/InMemoryCacheImpl.java
+++ b/core/cache/src/main/java/org/n52/sos/cache/InMemoryCacheImpl.java
@@ -1359,11 +1359,14 @@ public class InMemoryCacheImpl extends AbstractStaticContentCache implements Wri
     @Override
     public void removeFeaturesOfInterestForOffering(final String offering) {
         notNullOrEmpty(OFFERING, offering);
-        LOG.trace("Removing featuresOfInterest for offering {}", offering);
-        for (String featureOfInterest : featuresOfInterestForOfferings.get(offering)) {
-            this.offeringsForFeaturesOfInterest.removeWithKey(featureOfInterest, offering);
+        // prevent NPEs in foreach of Map.get(..)
+        if (featuresOfInterestForOfferings.containsKey(offering)) {
+            LOG.trace("Removing featuresOfInterest for offering {}", offering);
+            for (String featureOfInterest : featuresOfInterestForOfferings.get(offering)) {
+                this.offeringsForFeaturesOfInterest.removeWithKey(featureOfInterest, offering);
+            }
+            this.featuresOfInterestForOfferings.remove(offering);
         }
-        this.featuresOfInterestForOfferings.remove(offering);
     }
 
     @Override


### PR DESCRIPTION
Fixes: 

```
2017-06-05 16:29:26,290 ERROR [http-nio-127.0.0.1-8080-exec-20] [SosEventBus.java:261] Error handling event SensorDeletion[request=org.n52.sos.request.DeleteSensorRequest[service=SOS, version=2.0.0, operation=DeleteSensor], response=org.n52.sos.response.DeleteSensorResponse[service=SOS, version=2.0.0]] by handler org.n52.sos.cache.ctrl.DefaultContentModificationListener@24a5d753
java.lang.NullPointerException: null
	at org.n52.sos.cache.InMemoryCacheImpl.removeFeaturesOfInterestForOffering(InMemoryCacheImpl.java:1363) ~[InMemoryCacheImpl.class:na]
	at org.n52.sos.cache.ctrl.action.SensorDeletionUpdate.execute(SensorDeletionUpdate.java:101) ~[SensorDeletionUpdate.class:na]
	at org.n52.sos.cache.ctrl.ContentCacheControllerImpl$PartialUpdate.execute(ContentCacheControllerImpl.java:254) ~[ContentCacheControllerImpl$PartialUpdate.class:na]
	at org.n52.sos.cache.ctrl.ContentCacheControllerImpl.executePartial(ContentCacheControllerImpl.java:146) ~[ContentCacheControllerImpl.class:na]
	at org.n52.sos.cache.ctrl.ContentCacheControllerImpl.update(ContentCacheControllerImpl.java:122) ~[ContentCacheControllerImpl.class:na]
	at org.n52.sos.cache.ctrl.DefaultContentModificationListener.handle(DefaultContentModificationListener.java:112) ~[DefaultContentModificationListener.class:na]
	at org.n52.sos.cache.ctrl.DefaultContentModificationListener.handle(DefaultContentModificationListener.java:94) ~[DefaultContentModificationListener.class:na]
	at org.n52.sos.event.SosEventBus$HandlerExecution.run(SosEventBus.java:259) ~[SosEventBus$HandlerExecution.class:na]
	at org.n52.sos.event.SosEventBus.submit(SosEventBus.java:162) [SosEventBus.class:na]
	at org.n52.sos.event.SosEventBus.fire(SosEventBus.java:70) [SosEventBus.class:na]
	at org.n52.sos.request.operator.SosDeleteSensorOperatorV20.receive(SosDeleteSensorOperatorV20.java:70) [SosDeleteSensorOperatorV20.class:na]
	at org.n52.sos.request.operator.SosDeleteSensorOperatorV20.receive(SosDeleteSensorOperatorV20.java:53) [SosDeleteSensorOperatorV20.class:na]
	at org.n52.sos.request.operator.AbstractRequestOperator.receiveRequest(AbstractRequestOperator.java:173) [AbstractRequestOperator.class:na]
	at org.n52.sos.request.operator.AbstractTransactionalRequestOperator.receiveRequest(AbstractTransactionalRequestOperator.java:68) [AbstractTransactionalRequestOperator.class:na]
	at org.n52.sos.service.operator.AbstractServiceOperator.receiveRequest(AbstractServiceOperator.java:61) [AbstractServiceOperator.class:na]
	at org.n52.sos.binding.PoxBinding.doPostOperation(PoxBinding.java:73) [PoxBinding.class:na]
	at org.n52.sos.service.SosService.doPost(SosService.java:140) [SosService.class:na]
```