### PR TITLE
Fix/4.3.14 hibernate directory gets resetted on save

### DIFF
--- a/hibernate/datasource/common/src/main/java/org/n52/sos/ds/datasource/AbstractHibernateDatasource.java
+++ b/hibernate/datasource/common/src/main/java/org/n52/sos/ds/datasource/AbstractHibernateDatasource.java
@@ -729,9 +729,14 @@ public abstract class AbstractHibernateDatasource extends AbstractHibernateCoreD
      */
     protected void addMappingFileDirectories(Map<String, Object> settings, Properties p) {
         StringBuilder builder = new StringBuilder();
-        builder.append(HIBERNATE_MAPPING_CORE_PATH);
-        builder.append(SessionFactoryProvider.PATH_SEPERATOR).append(
-                getDatabaseConceptMappingDirectory(settings));
+        if (settings.containsKey(SessionFactoryProvider.HIBERNATE_DIRECTORY)) {
+            // don't re-write setting if present
+            builder.append(settings.get(SessionFactoryProvider.HIBERNATE_DIRECTORY));
+        } else {
+            builder.append(HIBERNATE_MAPPING_CORE_PATH)
+                   .append(SessionFactoryProvider.PATH_SEPERATOR)
+                   .append(getDatabaseConceptMappingDirectory(settings));
+        }
         if (isTransactionalDatasource()) {
             Boolean t = (Boolean) settings.get(transactionalDefiniton.getKey());
             if (t != null && t) {

--- a/hibernate/session-factory/src/main/java/org/n52/sos/ds/hibernate/HibernateSessionHolder.java
+++ b/hibernate/session-factory/src/main/java/org/n52/sos/ds/hibernate/HibernateSessionHolder.java
@@ -37,16 +37,16 @@ import org.n52.sos.service.Configurator;
 
 /**
  * @since 4.0.0
- * 
+ *
  */
 public class HibernateSessionHolder {
 
     private final ConnectionProvider connectionProvider;
 
     public HibernateSessionHolder() {
-        this(Configurator.getInstance().getDataConnectionProvider());
+        this.connectionProvider = Configurator.getInstance().getDataConnectionProvider();
     }
-    
+
     public HibernateSessionHolder(ConnectionProvider connectionProvider) {
         this.connectionProvider = connectionProvider;
     }
@@ -60,13 +60,20 @@ public class HibernateSessionHolder {
 
     public Session getSession() throws OwsExceptionReport {
         try {
-            return getSession(connectionProvider.getConnection());
+            return getSession(getConnectionProvider().getConnection());
         } catch (ConnectionProviderException cpe) {
             throw new NoApplicableCodeException().causedBy(cpe).withMessage("Error while getting new Session!");
         }
     }
 
     public void returnSession(Session session) {
-        this.connectionProvider.returnConnection(session);
+        getConnectionProvider().returnConnection(session);
+    }
+
+    private ConnectionProvider getConnectionProvider() {
+        if (Configurator.getInstance() != null) {
+            return Configurator.getInstance().getDataConnectionProvider();
+        }
+        return connectionProvider;
     }
 }


### PR DESCRIPTION
* do not reset `HIBERNATE_DIRECTORY` setting when saving changes via admin interface
* avoid creating orphaned session objects after `Configurator` provides new `ConnectionProvider`