### PR TITLE
Feature: show client ip in admin settings transactional

### DIFF
--- a/spring/views/src/main/webapp/WEB-INF/views/admin/settings.jsp
+++ b/spring/views/src/main/webapp/WEB-INF/views/admin/settings.jsp
@@ -34,6 +34,53 @@
     <jsp:param name="activeMenu" value="admin" />
 </jsp:include>
 
+<%
+    String ip = request.getHeader("X-Forwarded-For");
+    if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+        ip = request.getHeader("Proxy-Client-IP");
+    }
+    if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+        ip = request.getHeader("WL-Proxy-Client-IP");
+    }
+    if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+        ip = request.getHeader("HTTP_CLIENT_IP");
+    }
+    if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+        ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+    }
+    if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+        ip = request.getRemoteAddr();
+    }
+    pageContext.setAttribute("clientIp", ip);
+%>
+
+<script type="text/javascript">
+    function waitForElementToDisplayAfter(selector, time, content) {
+        if($(selector).length > 0) {
+            $(selector).after(content);
+            return;
+        }
+        else {
+            setTimeout(function() {
+                waitForElementToDisplayAfter(selector, time, content);
+            }, time);
+        }
+    }
+
+    $( document ).ready(function() {
+        waitForElementToDisplayAfter(
+            "#service_transactionalallowedips > div.controls > span.help-block",
+            1000,
+            "<br /><span class='alert alert-info'>" +
+            "Consider entering the IP of your machine: " +
+            "<code>" +
+            "<c:out value="${clientIp}" escapeXml="false"/>" +
+            "</code>" +
+            "</span>"
+        );
+    });
+</script>
+
 <div class="row">
     <div class="span9">
         <h2>Change SOS Configuration</h2>

--- a/spring/views/src/main/webapp/WEB-INF/views/common/header.jsp
+++ b/spring/views/src/main/webapp/WEB-INF/views/common/header.jsp
@@ -55,11 +55,11 @@
 
         <c:if test="${sos:hasInstaller() and not sos:configurated(pageContext.servletContext)}">
             <script type="text/javascript">
-				$(function() {
-					showMessage('You first have to complete the installation process! Click <a href="<c:url value="/install/index" />"><strong>here</strong></a> to start it.', "error");
-				});
-			</script>
-		</c:if>
+                $(function() {
+                        showMessage('You first have to complete the installation process! Click <a href="<c:url value="/install/index" />"><strong>here</strong></a> to start it.', "error");
+                });
+	    </script>
+	</c:if>
 	</head>
 	<body>
 		<div id="wrap">


### PR DESCRIPTION
Add feature to show the current client IP next to the allowed transactional IPs not only in the installer but in the normal transactional settings tab in the admin/settings view, too.