### PR TITLE
Fix issue when the cache thread cound is equal or greater than the max connection count

### DIFF
--- a/core/api/src/main/java/org/n52/sos/ds/ConnectionProvider.java
+++ b/core/api/src/main/java/org/n52/sos/ds/ConnectionProvider.java
@@ -69,4 +69,11 @@ public interface ConnectionProvider extends Cleanupable, ConnectionProviderIdent
      */
     void initialize(Properties properties) throws ConfigurationException;
 
+    /**
+     * Get the max connections number
+     * 
+     * @return The max connection number
+     */
+    int getMaxConnections();
+
 }

--- a/core/sqlite-config/src/main/java/org/n52/sos/config/sqlite/SQLiteSessionFactory.java
+++ b/core/sqlite-config/src/main/java/org/n52/sos/config/sqlite/SQLiteSessionFactory.java
@@ -225,4 +225,9 @@ public class SQLiteSessionFactory extends AbstractSessionFactoryProvider {
     public String getConnectionProviderIdentifier() {
         return "sqLiteHibernate";
     }
+
+    @Override
+    public int getMaxConnections() {
+        return 0;
+    }
 }

--- a/extensions/aqd/ereporting/src/main/java/org/n52/sos/inspire/aqd/persistence/ReportingHeaderSQLiteSessionFactory.java
+++ b/extensions/aqd/ereporting/src/main/java/org/n52/sos/inspire/aqd/persistence/ReportingHeaderSQLiteSessionFactory.java
@@ -158,4 +158,9 @@ public class ReportingHeaderSQLiteSessionFactory extends AbstractSessionFactoryP
         }
         super.cleanup();
     }
+
+    @Override
+    public int getMaxConnections() {
+        return 0;
+    }
 }

--- a/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/SosCacheFeederDAO.java
+++ b/hibernate/dao/src/main/java/org/n52/sos/ds/hibernate/SosCacheFeederDAO.java
@@ -33,7 +33,6 @@ import static org.n52.sos.ds.hibernate.CacheFeederSettingDefinitionProvider.CACH
 import java.util.Collection;
 import java.util.List;
 
-import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.joda.time.Period;
 import org.joda.time.format.PeriodFormat;
@@ -69,8 +68,16 @@ public class SosCacheFeederDAO extends HibernateSessionHolder implements CacheFe
      */
     private int cacheThreadCount = 5;
 
+    /**
+     * Get the defined cache thread count or the maximum connection count minus
+     * one to avoid hanging threads during the cache update.
+     * 
+     * @return Defined cache thread count or the maximum connection count minus
+     *         one
+     */
     public int getCacheThreadCount() {
-        return cacheThreadCount;
+        int maxConnections = getConnectionProvider().getMaxConnections();
+        return maxConnections > 0 && cacheThreadCount >= maxConnections ? maxConnections - 1 : cacheThreadCount;
     }
 
     @Setting(CACHE_THREAD_COUNT)

--- a/hibernate/session-factory/src/main/java/org/n52/sos/ds/hibernate/HibernateSessionHolder.java
+++ b/hibernate/session-factory/src/main/java/org/n52/sos/ds/hibernate/HibernateSessionHolder.java
@@ -70,7 +70,7 @@ public class HibernateSessionHolder {
         getConnectionProvider().returnConnection(session);
     }
 
-    private ConnectionProvider getConnectionProvider() {
+    protected ConnectionProvider getConnectionProvider() {
         if (Configurator.getInstance() != null) {
             return Configurator.getInstance().getDataConnectionProvider();
         }

--- a/hibernate/session-factory/src/main/java/org/n52/sos/ds/hibernate/SessionFactoryProvider.java
+++ b/hibernate/session-factory/src/main/java/org/n52/sos/ds/hibernate/SessionFactoryProvider.java
@@ -49,6 +49,7 @@ import org.hibernate.tool.hbm2ddl.DatabaseMetadata;
 import org.hibernate.tool.hbm2ddl.SchemaUpdateScript;
 import org.n52.sos.ds.ConnectionProviderException;
 import org.n52.sos.ds.HibernateDatasourceConstants;
+import org.n52.sos.ds.hibernate.util.HibernateConstants;
 import org.n52.sos.exception.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,6 +62,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SessionFactoryProvider extends UnspecifiedSessionFactoryProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(SessionFactoryProvider.class);
+    private int maxConnections;
 
 
     /**
@@ -98,6 +100,9 @@ public class SessionFactoryProvider extends UnspecifiedSessionFactoryProvider {
     protected Configuration getConfiguration(Properties properties) throws ConfigurationException {
         try {
             Configuration configuration = new Configuration().configure("/sos-hibernate.cfg.xml");
+            if (properties.containsKey(HibernateConstants.C3P0_MAX_SIZE)) {
+                this.maxConnections = Integer.parseInt(properties.getProperty(HibernateConstants.C3P0_MAX_SIZE, "-1"));
+            }
             if (properties.containsKey(HIBERNATE_RESOURCES)) {
                 List<String> resources = (List<String>) properties.get(HIBERNATE_RESOURCES);
                 for (String resource : resources) {
@@ -152,5 +157,10 @@ public class SessionFactoryProvider extends UnspecifiedSessionFactoryProvider {
     @Override
     public String getConnectionProviderIdentifier() {
         return HibernateDatasourceConstants.ORM_CONNECTION_PROVIDER_IDENTIFIER;
+    }
+    
+    @Override
+    public int getMaxConnections() {
+        return maxConnections;
     }
 }


### PR DESCRIPTION
Fix issue when the cache thread cound is equal or greater than the max connection count.
In that case one or more offering cache update task thread(s) hang(s) . To avoid this only max connection count minus one cache update threads should be created.