### PR TITLE
Docker Improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,19 +30,22 @@ ENV FAROE_CONFIGURATION /etc/sos/configuration.json
 ENV WEBAPP ${JETTY_BASE}/webapps/ROOT
 ENV HELGOLAND ${WEBAPP}/static/client/helgoland
 
-COPY --from=BUILD /usr/src/app/webapp/target/52n-sos-webapp ${WEBAPP}
-COPY ./docker/logback.xml    ${WEBAPP}/WEB-INF/classes/
-COPY ./docker/helgoland.json ${HELGOLAND}/assets/settings.json
-COPY ./docker/default-config /etc/sos
+COPY --chown=jetty:jetty --from=BUILD /usr/src/app/webapp/target/52n-sos-webapp ${WEBAPP}
+COPY --chown=jetty:jetty ./docker/logback.xml    ${WEBAPP}/WEB-INF/classes/
+COPY --chown=jetty:jetty ./docker/helgoland.json ${HELGOLAND}/assets/settings.json
+COPY --chown=jetty:jetty ./docker/default-config /etc/sos
 
 USER root
 COPY --from=BCRYPT_BUILD /usr/src/app /usr/lib/java-brcypt
 COPY docker/bcrypt/bcrypt.sh /usr/local/bin/bcrypt
 COPY docker/sos-entrypoint.sh /usr/local/bin
 
+
 RUN mkdir -p ${WEBAPP}/WEB-INF/tmp \
  && ln -s /etc/sos ${WEBAPP}/WEB-INF/config \
- && chown -R jetty:jetty ${WEBAPP} /etc/sos \
+ && chown -R jetty:jetty ${WEBAPP}/WEB-INF/tmp \
+                         ${WEBAPP}/WEB-INF/config \
+                         /etc/sos \
  && chmod +x /usr/local/bin/sos-entrypoint.sh \
              /usr/local/bin/bcrypt
 USER jetty:jetty

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ FROM jetty:jre8-alpine
 
 USER root
 RUN  set -ex \
- && apk add --no-cache jq \
+ && apk add --no-cache jq gettext \
  && wget -q -P /usr/local/bin https://raw.githubusercontent.com/52North/arctic-sea/master/etc/faroe-entrypoint.sh \
  && chmod +x /usr/local/bin/faroe-entrypoint.sh
 USER jetty:jetty
@@ -29,10 +29,12 @@ USER jetty:jetty
 ENV FAROE_CONFIGURATION /etc/sos/configuration.json
 ENV WEBAPP ${JETTY_BASE}/webapps/ROOT
 ENV HELGOLAND ${WEBAPP}/static/client/helgoland
+ENV HELGOLAND_CONFIG ${HELGOLAND}/assets/settings.json
 
 COPY --chown=jetty:jetty --from=BUILD /usr/src/app/webapp/target/52n-sos-webapp ${WEBAPP}
 COPY --chown=jetty:jetty ./docker/logback.xml    ${WEBAPP}/WEB-INF/classes/
-COPY --chown=jetty:jetty ./docker/helgoland.json ${HELGOLAND}/assets/settings.json
+COPY --chown=jetty:jetty ./docker/jetty-web.xml  ${WEBAPP}/WEB-INF/jetty-web.xml.template
+COPY --chown=jetty:jetty ./docker/helgoland.json ${HELGOLAND_CONFIG}
 COPY --chown=jetty:jetty ./docker/default-config /etc/sos
 
 USER root
@@ -55,7 +57,7 @@ VOLUME /etc/sos
 
 HEALTHCHECK --start-period=60s --interval=30s \
             --timeout=20s --retries=3 \
-  CMD wget http://localhost:8080/ -q -O - > /dev/null 2>&1
+  CMD wget http://localhost:8080${SOS_CONTEXT_PATH} -q -O - > /dev/null 2>&1
 
 LABEL maintainer="Carsten Hollmann <c.hollmann@52north.org>" \
       org.opencontainers.image.title="52°North SOS" \
@@ -79,6 +81,7 @@ ENV SOS_ADMIN_USERNAME=admin \
     SOS_DATASOURCE_PASSWORD=postgres \
     SOS_DATASOURCE_DATABASE=sos \
     SOS_DATASOURCE_HOST=db \
-    SOS_DATASOURCE_PORT=5432
+    SOS_DATASOURCE_PORT=5432 \
+    SOS_CONTEXT_PATH=/
 
 CMD [ "java", "-jar", "/usr/local/jetty/start.jar" ]

--- a/docker/jetty-web.xml
+++ b/docker/jetty-web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+  <Set name="contextPath">${SOS_CONTEXT_PATH}</Set>
+</Configure>

--- a/docker/sos-entrypoint.sh
+++ b/docker/sos-entrypoint.sh
@@ -59,4 +59,24 @@ sos.feature.concept=DEFAULT_FEATURE_CONCEPT
 EOF
 fi
 
+
+# set the URL of the API in the Helgoland settings
+if [ -n "${EXTERNAL_URL}" ]; then
+  TEMP="$(mktemp)"
+  jq --arg value "${EXTERNAL_URL}" \
+      '(.datasetApis[] | select(.name = "localhost")).url |= $value' \
+      < ${HELGOLAND_CONFIG} \
+      > ${TEMP}
+  mv -f "${TEMP}" "${HELGOLAND_CONFIG}"
+fi
+
+
+# change the context path if required
+if [ -n "${SOS_CONTEXT_PATH}" -a ${SOS_CONTEXT_PATH} != "/" ]; then
+  envsubst '${SOS_CONTEXT_PATH}' \
+    < "${WEBAPP}/WEB-INF/jetty-web.xml.template" \
+    > "${WEBAPP}/WEB-INF/jetty-web.xml"
+fi
+
+
 exec "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -2020,7 +2020,7 @@
                 <plugin>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
-                    <version>9.4.28.v20200408</version>
+                    <version>9.4.29.v20200521</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
* By not chowning the complete webapp to jetty and instead use COPY --chown=jetty:jetty the image shrinks from 488MB down to 290MB.
* By setting the environment variable `SOS_CONTEXT_PATH` one can customize the context path of the webapp (this is implemented using a `jetty-web.xml`)
* If the environment variable `EXTERNAL_URL` is set to customize the embedded API, the Helgoland config is also adjusted