### PR TITLE
update spring-data-jpa from 2.7.11 to 2.7.14 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
 		<version.helgoland-adapters>2.0.4</version.helgoland-adapters>
 		<version.springframework>5.3.27</version.springframework>
 		<version.springframework.security>5.7.8</version.springframework.security>
-		<version.springframework.data>2.7.11</version.springframework.data>
+		<version.springframework.data>2.7.14</version.springframework.data>
 		<version.spring-data-entity-graph>2.7.10</version.spring-data-entity-graph>
 		<version.aspectj>1.9.9.1</version.aspectj>
 		<version.saxon>12.0</version.saxon>


### PR DESCRIPTION
Fixes #1566 
## What does this PR do?

This pull request updates the version of spring-data-jpa dependency from 2.7.11 to 2.7.14. This update is aimed at incorporating the latest bug fixes, improvements, and features introduced in version 2.7.14, ensuring that our project remains up-to-date with the latest changes in the Spring Data ecosystem.

## Changes Made:

Updated the version of spring-data-jpa in the parent pom.xml file from 2.7.11 to 2.7.14.

## Testing Performed:

Compiled and tested the project locally to ensure compatibility and verify that there are no regression issues with the updated version.
Verified that all existing functionality remains intact and that there are no conflicts or errors resulting from the dependency update.

## Additional Notes:

This update may require developers to refresh their dependencies or make adjustments in their local development environments.
Please review and merge this pull request at your earliest convenience.