### PR TITLE
1568 : adding a dummy change

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,9 @@ updates:
     versions: ">= 3.x"
   - dependency-name: "com.cosium.spring.data:*"
     versions: ">= 3.x"
+    rebase-strategy: "auto" # Automatically rebases PRs to resolve conflicts
+    pull-request-branch-name:
+      separator: "-" # Configures branch naming for PRs
+    labels:
+      - "dependencies"
+      - "auto-merge"


### PR DESCRIPTION
 the labels section automatically applies tags like dependencies and auto-merge to pull requests, making them easier to track and enabling automation workflows, such as auto-merging once all checks pass.